### PR TITLE
Notes from Braden's review

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ phd-cluster-template/
 │   ├── create-instance.sh      # Instance creation logic
 │   ├── delete-instance.sh      # Instance deletion logic
 │   └── *.sh                    # Utility scripts
-├── .github/workflows/          # GitHub Actions workflows
+├── .github/workflows/          # GitHub Actions workflows (not run directly; referenced by cluster-template workflows)
 │   ├── create-instance.yml     # Instance creation workflow
 │   └── delete-instance.yml     # Instance deletion workflow
 ```

--- a/README.md
+++ b/README.md
@@ -56,19 +56,16 @@ phd-cluster-template/
 ├── .github/workflows/          # GitHub Actions workflows
 │   ├── create-instance.yml     # Instance creation workflow
 │   └── delete-instance.yml     # Instance deletion workflow
-└── requirements/               # Python dependencies
 ```
 
 ## Quick Start
 
 ### 1. Generate a Cluster
 
-```bash
-# Install cookiecutter
-pip install -r https://raw.githubusercontent.com/open-craft/phd-cluster-template/refs/heads/main/requirements/base.txt
+The easiest way to start setting up a cluster is using [`uv`](https://docs.astral.sh/uv/):
 
-# Generate cluster template
-cookiecutter https://github.com/open-craft/phd-cluster-template.git --directory cluster-template
+```bash
+uvx cookiecutter https://github.com/open-craft/phd-cluster-template.git --directory cluster-template
 ```
 
 ### 2. Set Up Infrastructure

--- a/cluster-template/cookiecutter.json
+++ b/cluster-template/cookiecutter.json
@@ -1,9 +1,9 @@
 {
-  "environment": "production",
   "cluster_name": "PHD Production Cluster",
+  "short_description": "Kubernetes cluster to host Open edX instances",
+  "environment": "production",
   "cluster_slug": "{{ cookiecutter.cluster_name.lower().replace(' ', '-') }}",
   "cluster_domain": "{{ cookiecutter.cluster_slug.lower().replace('_', '-') + '.example.com' }}",
-  "short_description": "Kubernetes cluster to host Open edX instances",
   "cloud_provider": [
     "aws",
     "digitalocean"
@@ -17,5 +17,8 @@
     "https://github.com/{{ cookiecutter.git_organization }}/phd-{{ cookiecutter.cluster_slug.lower().replace('_', '-') }}.git",
     "https://github.com/{{ cookiecutter.git_organization }}/phd-{{ cookiecutter.cluster_slug.lower().replace('_', '-') }}-{{ cookiecutter.environment.lower().replace(' ', '-') }}.git",
     "https://github.com/{{ cookiecutter.git_organization }}/{{ cookiecutter.cluster_slug.lower().replace('_', '-') }}.git"
-  ]
+  ],
+  "__prompts__": {
+    "environment": "Name the environment (prod/stage/dev):"
+  }
 }

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,7 +1,0 @@
-cookiecutter==2.6.0
-jsonschema==4.25.1
-requests==2.32.5
-black==25.1.0
-isort==6.0.0
-jq==1.10.0
-yq==3.4.3


### PR DESCRIPTION
Changes in this PR:
1. I was wondering why there was a `requirements` file if the scripts aren't written in python. I figured out it was just to run cookiecutter, and I think there's no need to maintain such a list nor recommend installing things just to run cookiecutter - `uvx` is a much more elegant solution.
2. When I tested it out the first prompt was "environment (production): " and I wasn't really sure if that was the cluster name or prod/dev/stage or what. So I re-ordered the cookiecutter questions and added a more descriptive prompt for that question.



Other notes:

3. The resulting Terraform code has `//` double slashes in all the GitHub URLs (after `.git`):

    ```
    module "kubernetes_cluster" {
      source = "git::https://github.com/openedx/openedx-k8s-harmony.git//terraform/modules/aws/doks?ref=${local.harmony_terraform_module_version}"
    ```

4. This part of `providers.tf` seems wrong, and VS code is reporting t as an error:
    <img width="535" height="92" alt="Screenshot 2025-10-02 at 2 36 57 PM" src="https://github.com/user-attachments/assets/5e0932a3-2411-49b3-9f1d-542145f48016" />

5. When I run `source activate`, the last two lines of output seem like an error but it's unclear if it's an error or just a warning?
    
    ```
    Loading PHD helper scripts from https://raw.githubusercontent.com/open-craft/phd-cluster-template/main/scripts...
    [SUCCESS] PHD commands loaded successfully
    [INFO]    Loading context as environment variables
    [DEBUG]   jq command is installed
    [DEBUG]   Context loaded as environment variables
    PHD_CLUSTER_DOMAIN=braden-test-cluster.example.com
    PHD_ENVIRONMENT=production
    __vsc_update_prompt:6: RPROMPT: parameter not set                                                                                                                             
    show_virtual_env:1: VIRTUAL_ENV: parameter not set
    ```
6. I know it's too late, but I do share the concern about having so much code written in bash: https://forum.opencraft.com/t/sprint-updates-serenity/634/1222?u=braden
7. Do you plan to have some sort of versioning, so that the `main` branch's scripts can continue to work with existing clusters even if we make some major changes? In other words, if a cluster is created from this template, but the template keeps evolving, will the cluster's admin commands stop working at some point due to an incompatibility?