### PR TITLE
fix: use correct fork/version of picasso, removed unused workflow inputs and add missing cookiecutter defaults

### DIFF
--- a/.github/workflows/build-all.yml
+++ b/.github/workflows/build-all.yml
@@ -16,10 +16,6 @@ on:
         description: "Branch to clone the strain from"
         required: true
         type: string
-      TUTOR_VERSION:
-        description: "Version of the tutor to use"
-        required: true
-        type: string
       PICASSO_VERSION:
         description: "Picasso version"
         required: true
@@ -55,9 +51,7 @@ jobs:
       SERVICE: openedx
       STRAIN_REPOSITORY: ${{ inputs.STRAIN_REPOSITORY }}
       STRAIN_REPOSITORY_BRANCH: ${{ inputs.STRAIN_REPOSITORY_BRANCH }}
-      TUTOR_VERSION: ${{ inputs.TUTOR_VERSION }}
       PICASSO_VERSION: ${{ inputs.PICASSO_VERSION }}
-      PHD_CLI_VERSION: ${{ inputs.PHD_CLI_VERSION }}
       RUNNER_WORKFLOW_LABEL: ${{ inputs.RUNNER_WORKFLOW_LABEL }}
 
   build-mfe:
@@ -76,9 +70,7 @@ jobs:
       SERVICE: mfe
       STRAIN_REPOSITORY: ${{ inputs.STRAIN_REPOSITORY }}
       STRAIN_REPOSITORY_BRANCH: ${{ inputs.STRAIN_REPOSITORY_BRANCH }}
-      TUTOR_VERSION: ${{ inputs.TUTOR_VERSION }}
       PICASSO_VERSION: ${{ inputs.PICASSO_VERSION }}
-      PHD_CLI_VERSION: ${{ inputs.PHD_CLI_VERSION }}
       RUNNER_WORKFLOW_LABEL: ${{ inputs.RUNNER_WORKFLOW_LABEL }}
 
   generate-env-dir:
@@ -91,12 +83,8 @@ jobs:
       SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
     with:
       INSTANCE_NAME: ${{ inputs.INSTANCE_NAME }}
-      # Use openedx service for env generation (either service works, we just need one)
-      SERVICE: openedx
-      IMAGE_TAG: ${{ needs.build-openedx.outputs.image_tag }}
       STRAIN_REPOSITORY: ${{ inputs.STRAIN_REPOSITORY }}
       STRAIN_REPOSITORY_BRANCH: ${{ inputs.STRAIN_REPOSITORY_BRANCH }}
-      TUTOR_VERSION: ${{ inputs.TUTOR_VERSION }}
       PICASSO_VERSION: ${{ inputs.PICASSO_VERSION }}
       PHD_CLI_VERSION: ${{ inputs.PHD_CLI_VERSION }}
       RUNNER_WORKFLOW_LABEL: ${{ inputs.RUNNER_WORKFLOW_LABEL }}

--- a/.github/workflows/build-service.yml
+++ b/.github/workflows/build-service.yml
@@ -51,7 +51,7 @@ on:
 jobs:
   build:
     name: Build with Picasso
-    uses: open-craft/picasso/.github/workflows/build.yml@gabor/add-ghcr-support
+    uses: eduNEXT/picasso/.github/workflows/build.yml@main
     permissions:
       packages: write
       contents: read

--- a/.github/workflows/build-service.yml
+++ b/.github/workflows/build-service.yml
@@ -19,16 +19,8 @@ on:
         description: "Branch to clone the strain from"
         required: true
         type: string
-      TUTOR_VERSION:
-        description: "Version of the tutor to use"
-        required: true
-        type: string
       PICASSO_VERSION:
         description: "Picasso version"
-        required: true
-        type: string
-      PHD_CLI_VERSION:
-        description: "PHD CLI version"
         required: true
         type: string
       RUNNER_WORKFLOW_LABEL:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,10 +19,6 @@ on:
         description: "Branch to clone the strain from"
         required: true
         type: string
-      TUTOR_VERSION:
-        description: "Version of the tutor to use"
-        required: true
-        type: string
       PICASSO_VERSION:
         description: "Picasso version"
         required: true
@@ -66,9 +62,7 @@ jobs:
       SERVICE: ${{ inputs.SERVICE }}
       STRAIN_REPOSITORY: ${{ inputs.STRAIN_REPOSITORY }}
       STRAIN_REPOSITORY_BRANCH: ${{ inputs.STRAIN_REPOSITORY_BRANCH }}
-      TUTOR_VERSION: ${{ inputs.TUTOR_VERSION }}
       PICASSO_VERSION: ${{ inputs.PICASSO_VERSION }}
-      PHD_CLI_VERSION: ${{ inputs.PHD_CLI_VERSION }}
       RUNNER_WORKFLOW_LABEL: ${{ inputs.RUNNER_WORKFLOW_LABEL }}
 
   generate-env-dir:
@@ -80,11 +74,8 @@ jobs:
       SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
     with:
       INSTANCE_NAME: ${{ inputs.INSTANCE_NAME }}
-      SERVICE: ${{ inputs.SERVICE }}
-      IMAGE_TAG: ${{ needs.build.outputs.image_tag }}
       STRAIN_REPOSITORY: ${{ inputs.STRAIN_REPOSITORY }}
       STRAIN_REPOSITORY_BRANCH: ${{ inputs.STRAIN_REPOSITORY_BRANCH }}
-      TUTOR_VERSION: ${{ inputs.TUTOR_VERSION }}
       PICASSO_VERSION: ${{ inputs.PICASSO_VERSION }}
       PHD_CLI_VERSION: ${{ inputs.PHD_CLI_VERSION }}
       RUNNER_WORKFLOW_LABEL: ${{ inputs.RUNNER_WORKFLOW_LABEL }}

--- a/.github/workflows/generate-env-dir.yml
+++ b/.github/workflows/generate-env-dir.yml
@@ -7,24 +7,12 @@ on:
         description: "Instance to create"
         required: true
         type: string
-      SERVICE:
-        description: "Service to update"
-        required: true
-        type: string
-      IMAGE_TAG:
-        description: "Image tag to use for the service"
-        required: true
-        type: string
       STRAIN_REPOSITORY:
         description: "The repository for strains to checkout. It should follow the format: ORGANIZATION/REPO"
         required: true
         type: string
       STRAIN_REPOSITORY_BRANCH:
         description: "Branch to clone the strain from"
-        required: true
-        type: string
-      TUTOR_VERSION:
-        description: "Version of the tutor to use"
         required: true
         type: string
       PICASSO_VERSION:

--- a/cluster-template/cookiecutter.json
+++ b/cluster-template/cookiecutter.json
@@ -9,10 +9,12 @@
     "aws",
     "digitalocean"
   ],
+  "cloud_region": "{{ 'us-east-1' if cookiecutter.cloud_provider=='aws' else 'nyc3' }}",
   "harmony_module_version": "deaf58ed6dc8d2d60ba5fed42d0ad472944dfaf7",
   "opencraft_module_version": "d55c99f57ee6cdadbfe3b01e19e456fb38b29e21",
   "picasso_version": "main",
   "phd_cluster_template_version": "main",
+  "tutor_version": "v20.0.2",
   "github_organization": "open-craft",
   "github_repository": "git@github.com:{{ cookiecutter.github_organization }}/phd-{{ cookiecutter.cluster_slug_normalized }}-cluster.git",
   "runner_workflow_label": [

--- a/cluster-template/phd-{{cookiecutter.cluster_slug_normalized}}-cluster/.github/workflows/build-all.yml
+++ b/cluster-template/phd-{{cookiecutter.cluster_slug_normalized}}-cluster/.github/workflows/build-all.yml
@@ -11,10 +11,6 @@ on:
         description: "Branch to clone the strain from"
         default: "main"
         type: string
-      TUTOR_VERSION:
-        description: "Version of the tutor to use"
-        default: "{{ cookiecutter.tutor_version }}"
-        type: string
       PICASSO_VERSION:
         description: "Picasso version"
         default: "{{ cookiecutter.picasso_version }}"
@@ -42,7 +38,6 @@ jobs:
       INSTANCE_NAME: {% raw %}${{ inputs.INSTANCE_NAME }}{% endraw %}
       STRAIN_REPOSITORY: {% raw %}${{ github.repository }}{% endraw %}
       STRAIN_REPOSITORY_BRANCH: {% raw %}${{ inputs.STRAIN_REPOSITORY_BRANCH }}{% endraw %}
-      TUTOR_VERSION: {% raw %}${{ inputs.TUTOR_VERSION }}{% endraw %}
       PICASSO_VERSION: {% raw %}${{ inputs.PICASSO_VERSION }}{% endraw %}
       PHD_CLI_VERSION: {% raw %}${{ inputs.PHD_CLI_VERSION }}{% endraw %}
       RUNNER_WORKFLOW_LABEL: {% raw %}${{ inputs.RUNNER_WORKFLOW_LABEL }}{% endraw %}

--- a/cluster-template/phd-{{cookiecutter.cluster_slug_normalized}}-cluster/.github/workflows/build.yml
+++ b/cluster-template/phd-{{cookiecutter.cluster_slug_normalized}}-cluster/.github/workflows/build.yml
@@ -18,10 +18,6 @@ on:
         description: "Branch to clone the strain from"
         default: "main"
         type: string
-      TUTOR_VERSION:
-        description: "Version of the tutor to use"
-        default: "{{ cookiecutter.tutor_version }}"
-        type: string
       PICASSO_VERSION:
         description: "Picasso version"
         default: "{{ cookiecutter.picasso_version }}"
@@ -50,7 +46,6 @@ jobs:
       SERVICE: {% raw %}${{ inputs.SERVICE }}{% endraw %}
       STRAIN_REPOSITORY: {% raw %}${{ github.repository }}{% endraw %}
       STRAIN_REPOSITORY_BRANCH: {% raw %}${{ inputs.STRAIN_REPOSITORY_BRANCH }}{% endraw %}
-      TUTOR_VERSION: {% raw %}${{ inputs.TUTOR_VERSION }}{% endraw %}
       PICASSO_VERSION: {% raw %}${{ inputs.PICASSO_VERSION }}{% endraw %}
       PHD_CLI_VERSION: {% raw %}${{ inputs.PHD_CLI_VERSION }}{% endraw %}
       RUNNER_WORKFLOW_LABEL: {% raw %}${{ inputs.RUNNER_WORKFLOW_LABEL }}{% endraw %}

--- a/cluster-template/phd-{{cookiecutter.cluster_slug_normalized}}-cluster/infrastructure-aws/providers.tf
+++ b/cluster-template/phd-{{cookiecutter.cluster_slug_normalized}}-cluster/infrastructure-aws/providers.tf
@@ -30,7 +30,7 @@ terraform {
 }
 
 provider "aws" {
-  region     = var.aws_region
+  region     = var.region
   access_key = var.aws_access_key_id
   secret_key = var.aws_secret_access_key
 }

--- a/cluster-template/phd-{{cookiecutter.cluster_slug_normalized}}-cluster/infrastructure-aws/variables.tf
+++ b/cluster-template/phd-{{cookiecutter.cluster_slug_normalized}}-cluster/infrastructure-aws/variables.tf
@@ -10,14 +10,9 @@ variable "aws_secret_access_key" {
   sensitive   = true
 }
 
-variable "aws_region" {
-  type        = string
-  description = "AWS region to create the resources in."
-}
-
 variable "region" {
   type        = string
-  default     = "us-east-1"
+  default     = "{{ cookiecutter.cloud_region }}"
   description = "AWS region to create the resources in."
 }
 

--- a/cluster-template/phd-{{cookiecutter.cluster_slug_normalized}}-cluster/infrastructure-digitalocean/providers.tf
+++ b/cluster-template/phd-{{cookiecutter.cluster_slug_normalized}}-cluster/infrastructure-digitalocean/providers.tf
@@ -1,7 +1,7 @@
 terraform {
   backend "s3" {
     endpoints = {
-      s3 = "https://{{ cookiecutter.region }}.digitaloceanspaces.com"
+      s3 = "https://{{ cookiecutter.cloud_region }}.digitaloceanspaces.com"
     }
 
     bucket = "tfstate-phd-{{ cookiecutter.cluster_slug_normalized }}-cluster-{{ cookiecutter.environment }}"

--- a/cluster-template/phd-{{cookiecutter.cluster_slug_normalized}}-cluster/infrastructure-digitalocean/variables.tf
+++ b/cluster-template/phd-{{cookiecutter.cluster_slug_normalized}}-cluster/infrastructure-digitalocean/variables.tf
@@ -18,7 +18,7 @@ variable "secret_access_key" {
 
 variable "region" {
   type        = string
-  default     = "nyc3"
+  default     = "{{ cookiecutter.cloud_region }}"
   description = "DigitalOcean region to create the resources in."
   validation {
     condition = contains([

--- a/tooling/phd/cli/cluster_create.py
+++ b/tooling/phd/cli/cluster_create.py
@@ -15,10 +15,12 @@ logger = get_logger(__name__)
 DEFAULT_ENVIRONMENT = "production"
 DEFAULT_SHORT_DESCRIPTION = "Kubernetes cluster to host Open edX instances"
 DEFAULT_CLOUD_PROVIDER = None
+DEFAULT_CLOUD_REGION = None
 DEFAULT_HARMONY_MODULE_VERSION = None
 DEFAULT_OPENCRAFT_MODULE_VERSION = None
 DEFAULT_PICASSO_VERSION = None
 DEFAULT_TEMPLATE_VERSION = None
+DEFAULT_TUTOR_VERSION = None
 DEFAULT_GITHUB_ORGANIZATION = None
 DEFAULT_TEMPLATE_REPOSITORY = "https://github.com/open-craft/phd-cluster-template.git"
 
@@ -29,10 +31,12 @@ def create_cluster(  # pylint: disable=too-many-branches,too-many-arguments,too-
     environment: str = DEFAULT_ENVIRONMENT,
     short_description: str = DEFAULT_SHORT_DESCRIPTION,
     cloud_provider: str | None = DEFAULT_CLOUD_PROVIDER,
+    cloud_region: str | None = DEFAULT_CLOUD_REGION,
     harmony_module_version: str | None = DEFAULT_HARMONY_MODULE_VERSION,
     opencraft_module_version: str | None = DEFAULT_OPENCRAFT_MODULE_VERSION,
     picasso_version: str | None = DEFAULT_PICASSO_VERSION,
     template_version: str | None = DEFAULT_TEMPLATE_VERSION,
+    tutor_version: str | None = DEFAULT_TUTOR_VERSION,
     github_organization: str | None = DEFAULT_GITHUB_ORGANIZATION,
     github_repository: str | None = None,
     template_repository: str = DEFAULT_TEMPLATE_REPOSITORY,
@@ -47,10 +51,12 @@ def create_cluster(  # pylint: disable=too-many-branches,too-many-arguments,too-
         environment: Environment name (default: "production")
         short_description: Short description of the cluster
         cloud_provider: Cloud provider (aws or digitalocean)
+        cloud_region: Region of the chosen cloud provider
         harmony_module_version: Harmony module version/commit hash
         opencraft_module_version: OpenCraft module version
         picasso_version: Picasso version
         template_version: PHD cluster template version
+        tutor_version: Tutor version
         github_organization: Git organization name
         github_repository: Git repository URL (if not provided, will be auto-generated)
         template_repository: Git URL of the cluster template repository
@@ -98,6 +104,9 @@ def create_cluster(  # pylint: disable=too-many-branches,too-many-arguments,too-
     if cloud_provider:
         extra_context["cloud_provider"] = [cloud_provider]
 
+    if cloud_region:
+        extra_context["cloud_region"] = [cloud_region]
+
     if harmony_module_version:
         extra_context["harmony_module_version"] = harmony_module_version
 
@@ -109,6 +118,9 @@ def create_cluster(  # pylint: disable=too-many-branches,too-many-arguments,too-
 
     if template_version:
         extra_context["phd_cluster_template_version"] = template_version
+
+    if tutor_version:
+        extra_context["tutor_version"] = tutor_version
 
     if github_organization:
         extra_context["github_organization"] = github_organization
@@ -170,6 +182,11 @@ def main() -> None:
         help=f"Cloud provider (default: {DEFAULT_CLOUD_PROVIDER})",
     )
     parser.add_argument(
+        "--cloud-region",
+        default=DEFAULT_CLOUD_REGION,
+        help=f"Cloud provider region (default: {DEFAULT_CLOUD_REGION})",
+    )
+    parser.add_argument(
         "--harmony-module-version",
         default=DEFAULT_HARMONY_MODULE_VERSION,
         help=f"Harmony module version/commit hash (default: {DEFAULT_HARMONY_MODULE_VERSION})",
@@ -188,6 +205,11 @@ def main() -> None:
         "--template-version",
         default=DEFAULT_TEMPLATE_VERSION,
         help=f"PHD cluster template version (default: {DEFAULT_TEMPLATE_VERSION})",
+    )
+    parser.add_argument(
+        "--tutor-version",
+        default=DEFAULT_TUTOR_VERSION,
+        help=f"Tutor version (default: {DEFAULT_TUTOR_VERSION})",
     )
     parser.add_argument(
         "--github-organization",
@@ -219,10 +241,12 @@ def main() -> None:
             args.environment,
             args.short_description,
             args.cloud_provider,
+            args.cloud_region,
             args.harmony_module_version,
             args.opencraft_module_version,
             args.picasso_version,
             args.template_version,
+            args.tutor_version,
             args.github_organization,
             args.github_repository,
             args.template_repository,


### PR DESCRIPTION
## Description

This PR: 
1. Changes the fork/branch of picasso to `eduNEXT`/`main` from the custom fork and branch configured currently.
2. Removed unused workflow inputs
3. Adds a couple of missing cookie-cutter defaults and fixes usage of cookiecutter region in the cluster templates.

## Other information

Private Ref : [SE-6534](https://tasks.opencraft.com/browse/SE-6534)