### PR TITLE
fix: set correct mongodb password to config

### DIFF
--- a/manifests/phd-mongodb-provision-template.yml
+++ b/manifests/phd-mongodb-provision-template.yml
@@ -43,6 +43,9 @@ spec:
       - name: atlas-cluster-name
         description: "MongoDB Atlas cluster name (for Atlas provider)"
         value: ""
+      - name: k8s-api-bearer-token
+        description: "Kubernetes API bearer token"
+        value: ""
 
   templates:
     - name: main
@@ -134,27 +137,45 @@ spec:
           #!/bin/sh
           set -e
 
+          NAMESPACE="{{workflow.parameters.namespace}}"
+          DATABASE_NAME="{{workflow.parameters.database-name}}"
           USERNAME="{{workflow.parameters.username}}"
+          PASSWORD="{{workflow.parameters.password}}"
           MONGODB_CLUSTER_ID="{{workflow.parameters.mongodb-cluster-id}}"
+          K8s_API_BEARER_TOKEN="{{workflow.parameters.k8s-api-bearer-token}}"
 
           echo "Creating user via DigitalOcean API: $USERNAME"
 
           RESPONSE=$(curl -s -X POST \
             -H "Content-Type: application/json" \
             -H "Authorization: Bearer $DIGITALOCEAN_TOKEN" \
-            -d "{\"name\": \"$USERNAME\"}" \
+            -d "{\"name\": \"$USERNAME\", \"settings\": {\"mongo_user_settings\": {\"databases\": [\"$DATABASE_NAME\"], \"role\": \"dbAdmin\"}}}" \
             "https://api.digitalocean.com/v2/databases/$MONGODB_CLUSTER_ID/users")
 
           if echo "$RESPONSE" | grep -q "\"name\":\"$USERNAME\""; then
             echo "User $USERNAME created successfully"
-            USER_PASSWORD=$(echo "$RESPONSE" | grep -o '"password":"[^"]*"' | cut -d'"' -f4)
-            echo "Generated password: $USER_PASSWORD"
-            echo "⚠ Note: DigitalOcean manages user passwords. The password in config may differ."
+            PASSWORD=$(echo "$RESPONSE" | grep -o '"password":"[^"]*"' | cut -d'"' -f4)
           elif echo "$RESPONSE" | grep -q "already exists"; then
             echo "User $USERNAME already exists"
           else
             echo "Failed to create user $USERNAME: $RESPONSE"
             exit 1
+          fi
+
+          echo "Saving MongoDB user password to kubernetes secret"
+
+          K8S_RESPONSE=$(curl -s -X POST \
+            -H "Content-Type: application/json" \
+            -H "Authorization: $K8s_API_BEARER_TOKEN" \
+            --cacert /var/run/secrets/kubernetes.io/serviceaccount/ca.crt \
+            -d "{\"apiVersion\": \"v1\",\"kind\": \"Secret\",\"metadata\": {\"name\": \"phd-mongodb-user-password\",\"namespace\": \"$NAMESPACE\"},\"type\": \"Opaque\",\"stringData\": {\"phd-mongodb-user-password\": \"$PASSWORD\"}}" \
+            "https://kubernetes.default.svc/api/v1/namespaces/$NAMESPACE/secrets")
+
+          if echo "$K8S_RESPONSE" | grep -q "\"kind\": \"Secret\""; then
+            echo "MongoDB user password saved to kubernetes secret \"phd-mongodb-user-password\" in namespace $NAMESPACE"
+          else
+            echo "Failed to save MongoDB user password in secret"
+            echo "⚠ Note: The MongoDB user password in config may differ."
           fi
 
           echo ""
@@ -273,10 +294,12 @@ spec:
           #!/bin/bash
           set -euo pipefail
 
+          NAMESPACE="{{workflow.parameters.namespace}}"
           USERNAME="{{workflow.parameters.username}}"
           PASSWORD="{{workflow.parameters.password}}"
           DATABASE_NAME="{{workflow.parameters.database-name}}"
           PROJECT_ID="{{workflow.parameters.atlas-project-id}}"
+          K8s_API_BEARER_TOKEN="{{workflow.parameters.k8s-api-bearer-token}}"
 
           # Install Atlas CLI from official MongoDB package
           echo "Installing MongoDB Atlas CLI..."
@@ -316,6 +339,22 @@ spec:
               echo "✗ Failed to create/update user $USERNAME"
               exit 1
             fi
+          fi
+
+          echo "Saving MongoDB Atlas user password to kubernetes secret"
+
+          K8S_RESPONSE=$(curl -s -X POST \
+            -H "Content-Type: application/json" \
+            -H "Authorization: $K8s_API_BEARER_TOKEN" \
+            --cacert /var/run/secrets/kubernetes.io/serviceaccount/ca.crt \
+            -d "{\"apiVersion\": \"v1\",\"kind\": \"Secret\",\"metadata\": {\"name\": \"phd-mongodb-user-password\",\"namespace\": \"$NAMESPACE\"},\"type\": \"Opaque\",\"stringData\": {\"phd-mongodb-user-password\": \"$PASSWORD\"}}" \
+            "https://kubernetes.default.svc/api/v1/namespaces/$NAMESPACE/secrets")
+
+          if echo "$K8S_RESPONSE" | grep -q "\"kind\": \"Secret\""; then
+            echo "MongoDB Atlas user password saved to kubernetes secret \"phd-mongodb-user-password\" in namespace $NAMESPACE"
+          else
+            echo "Failed to save MongoDB Atlas user password in secret"
+            echo "⚠ Note: The MongoDB Atlas user password in config may differ."
           fi
 
           echo ""

--- a/manifests/phd-mongodb-provision-workflow.yml
+++ b/manifests/phd-mongodb-provision-workflow.yml
@@ -34,6 +34,8 @@ spec:
         value: "{{ PHD_INSTANCE_ATLAS_PROJECT_ID }}"
       - name: atlas-cluster-name
         value: "{{ PHD_INSTANCE_ATLAS_CLUSTER_NAME }}"
+      - name: k8s-api-bearer-token
+        value: "{{ PHD_KUBERNETES_API_BEARER_TOKEN }}"
   workflowTemplateRef:
     name: mongodb-provision-template
     clusterScope: true

--- a/tooling/phd/kubernetes.py
+++ b/tooling/phd/kubernetes.py
@@ -33,6 +33,24 @@ class KubernetesClient:
         self._rbac_v1 = client.RbacAuthorizationV1Api()
         self._logger = get_logger(__name__)
 
+    def get_api_bearer_token(self) -> str:
+        """
+        Get a valid kuberetes API bearer token
+
+        Raises:
+            KubernetesError: If bearer token not present in auth settings
+
+        Returns:
+            str: The API bearer token
+        """
+        auth_settings = self._api_client.configuration.auth_settings()
+        try:
+            return auth_settings.get("BearerToken")["value"]
+        except Exception as e:
+            raise KubernetesError(
+                f"Failed to get bearer token from auth settings: {e}"
+            ) from e
+
     def __get_manifest_from_url(self, url: str) -> str:
         """
         Get a Kubernetes manifest from a URL.

--- a/tooling/phd/utils.py
+++ b/tooling/phd/utils.py
@@ -236,6 +236,7 @@ def detect_local_template(  # pylint: disable=too-many-locals,too-many-nested-bl
 def build_instance_config(  # pylint: disable=too-many-locals,too-many-positional-arguments
     instance_name: str,
     config_data: dict,
+    k8s_api_bearer_token: str | None = None,
     platform_name: str | None = None,
     edx_platform_repository: str | None = None,
     edx_platform_version: str | None = None,
@@ -259,6 +260,9 @@ def build_instance_config(  # pylint: disable=too-many-locals,too-many-positiona
     instance_config = {
         "PHD_INSTANCE_NAME": instance_name,
     }
+
+    if k8s_api_bearer_token is not None:
+        instance_config["PHD_KUBERNETES_API_BEARER_TOKEN"] = k8s_api_bearer_token
 
     if platform_name is not None:
         instance_config["PHD_PLATFORM_NAME"] = platform_name


### PR DESCRIPTION
## Description

This PR:
1. Adds the correct RBAC to the DigitalOcean MongoDB user being provisioned when creating an instance.
2. Fixes a bug where the MongoDB password for DigitalOcean instances were incorrectly set in the instance config.

## Testing instructions

1. In an existing cluster, run the "Create Instance" workflow using Github Actions using this branch as the CLI version.
2. Verify you can successfully connect to the newly created mongodb database using the username and password saved in the config file.
3. Fetch details of the mongodb user using DigitalOcean's API. Replace the `$DIGITALOCEAN_TOKEN`, `database_cluster_uuid`, `username` with the appropriate values:
```
curl -X GET \
  -H "Content-Type: application/json" \
  -H "Authorization: Bearer $DIGITALOCEAN_TOKEN" \
  "https://api.digitalocean.com/v2/databases/{database_cluster_uuid}/users/{username}"
```
4. Verify the settings sections in the response has the correct RBAC details configured for the username.

## Deadline

"None" if there's no rush, or provide a specific date or event (and reason) if there is one.

## Other information

[SE-6534](https://tasks.opencraft.com/browse/SE-6534)