### PR TITLE
feat: implement GitHub SSO authentication

### DIFF
--- a/.github/workflows/scripts/cleanup_ghcr_instance_images.py
+++ b/.github/workflows/scripts/cleanup_ghcr_instance_images.py
@@ -380,7 +380,9 @@ def delete_package_version(
         details = exc.read().decode("utf-8", errors="replace")
         if exc.code == 404:
             # Deletions can race across concurrent jobs; treat not found as already deleted.
-            print(f"WARNING: Version {version_id} already deleted or unavailable (404).")
+            print(
+                f"WARNING: Version {version_id} already deleted or unavailable (404)."
+            )
             return False
         raise SystemExit(
             f"GitHub API request failed: DELETE {url} -> {exc.code} {details}"

--- a/docs/cluster/configuration.md
+++ b/docs/cluster/configuration.md
@@ -19,6 +19,10 @@ Optional:
 - **`LAUNCHPAD_ARGO_WORKFLOWS_VERSION`** -  Argo Workflows version (default: `stable`)
 - **`LAUNCHPAD_OPENCRAFT_MANIFESTS_URL`** -  Base URL for OpenCraft manifests
 - **`LAUNCHPAD_DOCKER_REGISTRY`** -  Registry hostname (e.g. `ghcr.io`)
+- **`LAUNCHPAD_ARGOCD_GITHUB_SSO_ENABLED`** -  Enable ArgoCD GitHub SSO via Dex (default: `false`)
+- **`LAUNCHPAD_ARGOCD_GITHUB_OAUTH_CLIENT_ID`** -  GitHub OAuth App client ID (required when GitHub SSO is enabled)
+- **`LAUNCHPAD_ARGOCD_GITHUB_OAUTH_CLIENT_SECRET`** -  GitHub OAuth App client secret (required when GitHub SSO is enabled)
+- **`LAUNCHPAD_ARGOCD_GITHUB_ORGS`** -  Comma-separated GitHub org slugs allowed to sign in (required when GitHub SSO is enabled)
 
 ## Terraform/OpenTofu Variables
 

--- a/docs/infrastructure/provisioning.md
+++ b/docs/infrastructure/provisioning.md
@@ -142,6 +142,34 @@ export LAUNCHPAD_CLUSTER_DOMAIN="cluster.domain"
 export LAUNCHPAD_DOCKER_REGISTRY_CREDENTIALS="base64 encoded docker registry credentials"
 ```
 
+**Optional: enable GitHub SSO for ArgoCD**:
+
+1. Create a GitHub OAuth App with callback URL:
+   `https://argocd.<cluster-domain>/api/dex/callback`
+2. Export these variables before running `launchpad_install_argo`:
+
+```bash
+export LAUNCHPAD_ARGOCD_GITHUB_SSO_ENABLED="true"
+export LAUNCHPAD_ARGOCD_GITHUB_OAUTH_CLIENT_ID="github-oauth-client-id"
+export LAUNCHPAD_ARGOCD_GITHUB_OAUTH_CLIENT_SECRET="github-oauth-client-secret"
+export LAUNCHPAD_ARGOCD_GITHUB_ORGS="your-github-org,another-org"
+```
+
+Or provide SSO values directly on the install command (manual setup path):
+
+```bash
+launchpad_install_argo --argocd-only \
+  --enable-argocd-github-sso \
+  --argocd-github-oauth-client-id "github-oauth-client-id" \
+  --argocd-github-oauth-client-secret "github-oauth-client-secret" \
+  --argocd-github-orgs "your-github-org,another-org"
+```
+
+When provided, CLI flags override the corresponding `LAUNCHPAD_ARGOCD_GITHUB_*` environment variables for that run.
+
+For existing ArgoCD installations and manual patch commands, see
+[Enabling ArgoCD GitHub SSO](../user-guides/enabling-argocd-github-sso.md).
+
 **Install Both Tools**:
 
 ```bash
@@ -184,6 +212,20 @@ After installation, you can access:
 - **Argo Workflows**: `http://localhost:2746` (after `kubectl port-forward svc/argo-server 2746:2746 -n argo`)
 
 Use the admin password (displayed during installation or set via `LAUNCHPAD_ARGO_ADMIN_PASSWORD`) to log in.
+
+If GitHub SSO is enabled, restart ArgoCD Dex and server pods after installation:
+
+```bash
+kubectl delete pod -n argocd -l app.kubernetes.io/name=argocd-dex-server
+kubectl delete pod -n argocd -l app.kubernetes.io/name=argocd-server
+```
+
+GitHub SSO only authenticates users. Authorization still comes from ArgoCD RBAC policies.
+Add user/group mappings in [`manifests/argocd-rbac-config.yml`](../../manifests/argocd-rbac-config.yml), for example:
+
+```csv
+g, github:your-username, role:developer
+```
 
 ### Step 5: Configure ArgoCD Projects and Repository
 
@@ -323,6 +365,10 @@ Users can access ArgoCD via:
 - `LAUNCHPAD_OPENCRAFT_MANIFESTS_URL`: Base URL for OpenCraft manifests (default: GitHub raw content URL)
 - `LAUNCHPAD_DOCKER_REGISTRY`: Docker registry hostname (default: `ghcr.io`)
 - `LAUNCHPAD_DOCKER_REGISTRY_CREDENTIALS`: Base64-encoded registry credentials for private image pulls
+- `LAUNCHPAD_ARGOCD_GITHUB_SSO_ENABLED`: Enable ArgoCD GitHub SSO via Dex (default: `false`)
+- `LAUNCHPAD_ARGOCD_GITHUB_OAUTH_CLIENT_ID`: GitHub OAuth App client ID (required when GitHub SSO is enabled)
+- `LAUNCHPAD_ARGOCD_GITHUB_OAUTH_CLIENT_SECRET`: GitHub OAuth App client secret (required when GitHub SSO is enabled)
+- `LAUNCHPAD_ARGOCD_GITHUB_ORGS`: Comma-separated GitHub org slugs allowed to sign in (required when GitHub SSO is enabled)
 
 ### Terraform Variables
 

--- a/docs/user-guides/enabling-argocd-github-sso.md
+++ b/docs/user-guides/enabling-argocd-github-sso.md
@@ -1,0 +1,260 @@
+# Enabling ArgoCD GitHub SSO
+
+This guide explains how to enable GitHub SSO for ArgoCD using the bundled Dex
+server. It covers both a fresh ArgoCD installation and an existing installation.
+
+## Prerequisites
+
+Create a GitHub OAuth App with these values:
+
+- **Homepage URL**: `https://argocd.<cluster-domain>`
+- **Authorization callback URL**: `https://argocd.<cluster-domain>/api/dex/callback`
+
+Keep the OAuth client ID and client secret available for the install or patch
+commands below.
+
+Use the GitHub organization slugs that should be allowed to sign in. For example,
+`open-craft` allows members of the `open-craft` GitHub organization to
+authenticate. Authorization is still handled separately by ArgoCD RBAC.
+
+## New ArgoCD Installation
+
+Use this path when ArgoCD is not installed yet, or when you are intentionally
+re-running the Launchpad ArgoCD installer.
+
+```bash
+set -euo pipefail
+
+export LAUNCHPAD_CLUSTER_DOMAIN="prod.opencraft.hosting"
+export LAUNCHPAD_DOCKER_REGISTRY_CREDENTIALS="base64 encoded docker registry credentials"
+
+launchpad_install_argo --argocd-only \
+  --enable-argocd-github-sso \
+  --argocd-github-oauth-client-id "github-oauth-client-id" \
+  --argocd-github-oauth-client-secret "github-oauth-client-secret" \
+  --argocd-github-orgs "open-craft"
+```
+
+If you are installing both ArgoCD and Argo Workflows, omit `--argocd-only`:
+
+```bash
+set -euo pipefail
+
+launchpad_install_argo \
+  --enable-argocd-github-sso \
+  --argocd-github-oauth-client-id "github-oauth-client-id" \
+  --argocd-github-oauth-client-secret "github-oauth-client-secret" \
+  --argocd-github-orgs "open-craft"
+```
+
+The installer configures:
+
+- `argocd-cm` with `url: https://argocd.<cluster-domain>`
+- `argocd-cm` with a Dex GitHub connector
+- `argocd-secret` with `dex.github.clientSecret`
+
+Restart the ArgoCD Dex and server pods after the install:
+
+```bash
+set -euo pipefail
+
+kubectl delete pod -n argocd -l app.kubernetes.io/name=argocd-dex-server
+kubectl delete pod -n argocd -l app.kubernetes.io/name=argocd-server
+```
+
+## Existing ArgoCD Installation
+
+Use this path when ArgoCD is already installed and you want to configure SSO
+without replacing the cluster.
+
+### Option 1: Re-run the Launchpad ArgoCD installer
+
+This is the preferred path when you have the current Launchpad tooling available.
+
+```bash
+set -euo pipefail
+
+export LAUNCHPAD_CLUSTER_DOMAIN="prod.opencraft.hosting"
+
+launchpad_install_argo --argocd-only \
+  --enable-argocd-github-sso \
+  --argocd-github-oauth-client-id "github-oauth-client-id" \
+  --argocd-github-oauth-client-secret "github-oauth-client-secret" \
+  --argocd-github-orgs "open-craft"
+```
+
+### Option 2: Patch Kubernetes resources manually
+
+Use direct `kubectl` patches if you cannot re-run the Launchpad installer.
+
+```bash
+set -euo pipefail
+
+export LAUNCHPAD_CLUSTER_DOMAIN="prod.opencraft.hosting"
+export LAUNCHPAD_ARGOCD_GITHUB_OAUTH_CLIENT_ID="github-oauth-client-id"
+export LAUNCHPAD_ARGOCD_GITHUB_OAUTH_CLIENT_SECRET="github-oauth-client-secret"
+export LAUNCHPAD_ARGOCD_GITHUB_ORGS="open-craft"
+
+kubectl patch configmap argocd-cm \
+  -n argocd \
+  --type merge \
+  --patch-file /dev/stdin <<EOF
+data:
+  url: "https://argocd.${LAUNCHPAD_CLUSTER_DOMAIN}"
+  dex.config: |
+    connectors:
+    - type: github
+      id: github
+      name: GitHub
+      config:
+        clientID: ${LAUNCHPAD_ARGOCD_GITHUB_OAUTH_CLIENT_ID}
+        clientSecret: \$dex.github.clientSecret
+        orgs:
+        - name: ${LAUNCHPAD_ARGOCD_GITHUB_ORGS}
+EOF
+
+kubectl patch secret argocd-secret \
+  -n argocd \
+  --type merge \
+  --patch-file /dev/stdin <<EOF
+stringData:
+  dex.github.clientSecret: "${LAUNCHPAD_ARGOCD_GITHUB_OAUTH_CLIENT_SECRET}"
+EOF
+```
+
+If you allow multiple GitHub organizations, patch `dex.config` with one
+`- name: <org-slug>` entry per organization:
+
+```yaml
+orgs:
+- name: open-craft
+- name: another-org
+```
+
+### Patch the ingress
+
+The ArgoCD ingress must not use `nginx.ingress.kubernetes.io/app-root: /login`
+with SSO. That nginx redirect can send the browser back to the login page after
+Dex reports a successful login.
+
+Remove the annotation from an existing ingress:
+
+```bash
+set -euo pipefail
+
+kubectl annotate ingress argocd-server-ingress \
+  -n argocd \
+  nginx.ingress.kubernetes.io/app-root- \
+  --overwrite
+```
+
+Confirm it is gone:
+
+```bash
+set -euo pipefail
+
+kubectl get ingress argocd-server-ingress \
+  -n argocd \
+  -o jsonpath='{.metadata.annotations.nginx\.ingress\.kubernetes\.io/app-root}{"\n"}'
+```
+
+The command should print an empty line.
+
+### Restart ArgoCD
+
+Restart Dex and the ArgoCD API server after changing SSO settings:
+
+```bash
+set -euo pipefail
+
+kubectl delete pod -n argocd -l app.kubernetes.io/name=argocd-dex-server
+kubectl delete pod -n argocd -l app.kubernetes.io/name=argocd-server
+```
+
+Hard-refresh the browser or clear site data for the ArgoCD host before testing
+the login flow again.
+
+## Configure RBAC
+
+GitHub SSO authenticates the user; ArgoCD RBAC decides what the user can do.
+The default Launchpad RBAC policy grants `role:readonly` by default.
+
+Map GitHub users or groups in `argocd-rbac-cm`. If you manage RBAC from
+manifests, prefer updating `manifests/argocd-rbac-config.yml` or your
+cluster-specific overlay instead of patching the live ConfigMap.
+
+For example, if Dex reports the group claim `open-craft:Core`, add this line to
+the existing `policy.csv` while preserving the other role definitions:
+
+```csv
+g, open-craft:Core, role:developer
+```
+
+For one-off debugging, edit the live ConfigMap carefully:
+
+```bash
+set -euo pipefail
+
+kubectl edit configmap argocd-rbac-cm -n argocd
+```
+
+Example:
+
+```yaml
+# Please edit the object below. Lines beginning with a '#' will be ignored,
+# and an empty file will abort the edit. If an error occurs while saving this file will be
+# reopened with the relevant failures.
+#
+apiVersion: v1
+data:
+  policy.csv: |2-
+    g, open-craft:Core, role:admin
+    g, oc-sandboxuser, role:readonly
+    g, sandboxuser, role:readonly
+kind: ConfigMap
+metadata:
+  annotations:
+    kubectl.kubernetes.io/last-applied-configuration: |
+      {"apiVersion":"v1","kind":"ConfigMap","metadata":{"labels":{"app.kubernetes.io/name":"argocd-rbac-cm","app.kubernetes.io/part-of":"argocd"},"name":"argocd-rbac-cm","namespace":"argocd"}}
+  creationTimestamp: "2026-01-19T17:20:36Z"
+  labels:
+    app.kubernetes.io/name: argocd-rbac-cm
+    app.kubernetes.io/part-of: argocd
+  name: argocd-rbac-cm
+  namespace: argocd
+  resourceVersion: "20663496"
+  uid: 417d19a5-904f-4db6-9c7b-030ac839fbba
+```
+
+Once edited, make sure the argo-server is restarted `kubectl delete pod -n argocd -l app.kubernetes.io/name=argocd-server`.
+
+## Verify SSO
+
+Check the external ArgoCD URL:
+
+```bash
+set -euo pipefail
+
+kubectl get configmap argocd-cm \
+  -n argocd \
+  -o jsonpath='{.data.url}{"\n"}'
+```
+
+It should be exactly `https://argocd.<cluster-domain>`.
+
+Open `https://argocd.<cluster-domain>/`, select GitHub login, and complete the
+OAuth flow. After login, the browser should remain authenticated and load the
+ArgoCD applications UI.
+
+If Dex and `argocd-server` report successful login but the browser returns to
+the login page, check the ingress first:
+
+```bash
+set -euo pipefail
+
+kubectl get ingress argocd-server-ingress \
+  -n argocd \
+  -o yaml
+```
+
+Make sure `nginx.ingress.kubernetes.io/app-root` is not present.

--- a/docs/user-guides/index.md
+++ b/docs/user-guides/index.md
@@ -10,6 +10,7 @@ This section contains step-by-step guides for specific tasks and scenarios when 
 - **[Use More Performant Runners](use-more-performant-runners.md)** -  Using Blacksmith runners for faster builds
 - **[Pull Request Sandboxes](pull-request-sandboxes.md)** -  Using sandbox environments for pull requests
 - **[Multi-Domain Setup](multi-domain-setup.md)** -  Serving an instance under multiple domains
+- **[Enabling ArgoCD GitHub SSO](enabling-argocd-github-sso.md)** -  Configuring GitHub SSO for new and existing ArgoCD installations
 - **[Migrating Instances from Grove](migrating-instances-from-grove.md)** - Step-by-step checklist to help instance migration
 
 ## Related Documentation

--- a/manifests/argocd-base-config.yml
+++ b/manifests/argocd-base-config.yml
@@ -10,3 +10,4 @@ metadata:
 data:
   users.anonymous.enabled: "false"
   exec.enabled: "true"
+  kustomize.buildOptions: --enable-helm

--- a/manifests/argocd-ingress.yml
+++ b/manifests/argocd-ingress.yml
@@ -10,7 +10,6 @@ metadata:
     nginx.ingress.kubernetes.io/ssl-redirect: "true"
     nginx.ingress.kubernetes.io/enable-cors: "true"
     nginx.ingress.kubernetes.io/proxy-body-size: "128M"
-    nginx.ingress.kubernetes.io/app-root: /login
     nginx.ingress.kubernetes.io/ssl-passthrough: "true"
     nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"
 spec:

--- a/tooling/launchpad/cli/argo_install.py
+++ b/tooling/launchpad/cli/argo_install.py
@@ -30,10 +30,119 @@ SYSTEM_NAMESPACES = {
     "kube-public",
     "kube-node-lease",
 }
+ARGOCD_NAMESPACE = "argocd"
 
 
 def _is_system_namespace(namespace: str) -> bool:
     return namespace in SYSTEM_NAMESPACES or namespace.startswith("kube-")
+
+
+def _split_csv_values(raw_value: str) -> list[str]:
+    """
+    Parse a comma-separated string into a list of non-empty trimmed values.
+    """
+    return [value.strip() for value in raw_value.split(",") if value.strip()]
+
+
+def _build_dex_github_config(client_id: str, github_orgs: list[str]) -> str:
+    """
+    Build the dex.config YAML payload for a GitHub connector.
+    """
+    org_lines = "\n".join(f"      - name: {org}" for org in github_orgs)
+    return (
+        "connectors:\n"
+        "- type: github\n"
+        "  id: github\n"
+        "  name: GitHub\n"
+        "  config:\n"
+        f"    clientID: {client_id}\n"
+        "    clientSecret: $dex.github.clientSecret\n"
+        "    orgs:\n"
+        f"{org_lines}"
+    )
+
+
+def _build_argocd_sso_cli_overrides(args: argparse.Namespace) -> dict[str, str | bool]:
+    """
+    Build ClusterConfig override values from CLI arguments.
+    """
+    overrides: dict[str, str | bool] = {}
+
+    if args.argocd_github_sso_enabled is not None:
+        overrides["argocd_github_sso_enabled"] = args.argocd_github_sso_enabled
+
+    if args.argocd_github_oauth_client_id is not None:
+        overrides["argocd_github_oauth_client_id"] = args.argocd_github_oauth_client_id
+
+    if args.argocd_github_oauth_client_secret is not None:
+        overrides["argocd_github_oauth_client_secret"] = (
+            args.argocd_github_oauth_client_secret
+        )
+
+    if args.argocd_github_orgs is not None:
+        overrides["argocd_github_orgs"] = args.argocd_github_orgs
+
+    return overrides
+
+
+def _configure_argocd_github_sso(
+    k8s: KubernetesClient,
+    cluster_config: ClusterConfig,
+) -> None:
+    """
+    Configure optional GitHub SSO for ArgoCD using Dex.
+    """
+    if not cluster_config.argocd_github_sso_enabled:
+        return
+
+    client_id = cluster_config.argocd_github_oauth_client_id.strip()
+    client_secret = cluster_config.argocd_github_oauth_client_secret.strip()
+    github_orgs = _split_csv_values(cluster_config.argocd_github_orgs)
+
+    missing_vars = []
+    if not client_id:
+        missing_vars.append("LAUNCHPAD_ARGOCD_GITHUB_OAUTH_CLIENT_ID")
+    if not client_secret:
+        missing_vars.append("LAUNCHPAD_ARGOCD_GITHUB_OAUTH_CLIENT_SECRET")
+    if not github_orgs:
+        missing_vars.append("LAUNCHPAD_ARGOCD_GITHUB_ORGS")
+
+    if missing_vars:
+        raise ConfigurationError(
+            "GitHub SSO is enabled, but required settings are missing: "
+            + ", ".join(missing_vars)
+        )
+
+    run_command_with_logging(
+        logger,
+        "configure ArgoCD Dex GitHub connector",
+        k8s.patch_config_map,
+        name="argocd-cm",
+        namespace=ARGOCD_NAMESPACE,
+        data={
+            "url": f"https://argocd.{cluster_config.cluster_domain}",
+            "dex.config": _build_dex_github_config(client_id, github_orgs),
+        },
+    )
+
+    run_command_with_logging(
+        logger,
+        "configure ArgoCD Dex GitHub OAuth secret",
+        k8s.patch_secret,
+        name="argocd-secret",
+        namespace=ARGOCD_NAMESPACE,
+        string_data={
+            "dex.github.clientSecret": client_secret,
+        },
+    )
+
+    logger.warning("Restart ArgoCD Dex and server pods to apply GitHub SSO changes:")
+    logger.warning(
+        "  kubectl delete pod -n argocd -l app.kubernetes.io/name=argocd-dex-server"
+    )
+    logger.warning(
+        "  kubectl delete pod -n argocd -l app.kubernetes.io/name=argocd-server"
+    )
 
 
 def _configure_registry_pull_secrets(
@@ -236,7 +345,7 @@ def install_argocd(cluster_config: ClusterConfig) -> None:
         logger,
         "create ArgoCD namespace",
         k8s.create_namespace,
-        "argocd",
+        ARGOCD_NAMESPACE,
     )
 
     run_command_with_logging(
@@ -244,7 +353,7 @@ def install_argocd(cluster_config: ClusterConfig) -> None:
         "install ArgoCD core components",
         k8s.apply_manifest_from_url,
         cluster_config.argocd_install_url,
-        "argocd",
+        ARGOCD_NAMESPACE,
     )
 
     run_command_with_logging(
@@ -252,7 +361,7 @@ def install_argocd(cluster_config: ClusterConfig) -> None:
         "ensure base ArgoCD configmap",
         k8s.apply_manifest_from_url,
         f"{cluster_config.opencraft_manifests_url}/argocd-base-config.yml",
-        "argocd",
+        ARGOCD_NAMESPACE,
     )
 
     run_command_with_logging(
@@ -260,7 +369,7 @@ def install_argocd(cluster_config: ClusterConfig) -> None:
         "ensure ArgoCD server role allows web terminal (pods/exec)",
         k8s.ensure_role_has_pods_exec,
         "argocd-server",
-        "argocd",
+        ARGOCD_NAMESPACE,
     )
 
     run_command_with_logging(
@@ -268,18 +377,20 @@ def install_argocd(cluster_config: ClusterConfig) -> None:
         "configure ArgoCD ingress",
         k8s.apply_manifest_from_url,
         f"{cluster_config.opencraft_manifests_url}/argocd-ingress.yml",
-        "argocd",
+        ARGOCD_NAMESPACE,
         {
             "LAUNCHPAD_CLUSTER_DOMAIN": cluster_config.cluster_domain,
         },
     )
+
+    _configure_argocd_github_sso(k8s, cluster_config)
 
     run_command_with_logging(
         logger,
         "configure ArgoCD admin password",
         k8s.apply_manifest_from_url,
         f"{cluster_config.opencraft_manifests_url}/argocd-admin-password.yml",
-        "argocd",
+        ARGOCD_NAMESPACE,
         {
             "LAUNCHPAD_CLUSTER_DOMAIN": cluster_config.cluster_domain,
             "LAUNCHPAD_ARGO_ADMIN_PASSWORD_BCRYPT": bcrypt_password(plaintext_password),
@@ -293,7 +404,7 @@ def install_argocd(cluster_config: ClusterConfig) -> None:
         _configure_registry_pull_secrets,
         k8s,
         cluster_config,
-        ["argocd"],
+        [ARGOCD_NAMESPACE],
         scan_existing_namespaces=False,
     )
 
@@ -323,6 +434,35 @@ def main():
         action="store_true",
         help="Install only Argo Workflows",
     )
+    sso_toggle_group = parser.add_mutually_exclusive_group()
+    sso_toggle_group.add_argument(
+        "--enable-argocd-github-sso",
+        dest="argocd_github_sso_enabled",
+        action="store_true",
+        help="Enable ArgoCD GitHub SSO via Dex for this install run",
+    )
+    sso_toggle_group.add_argument(
+        "--disable-argocd-github-sso",
+        dest="argocd_github_sso_enabled",
+        action="store_false",
+        help="Disable ArgoCD GitHub SSO via Dex for this install run",
+    )
+    parser.set_defaults(argocd_github_sso_enabled=None)
+    parser.add_argument(
+        "--argocd-github-oauth-client-id",
+        default=None,
+        help="GitHub OAuth App client ID for ArgoCD Dex connector",
+    )
+    parser.add_argument(
+        "--argocd-github-oauth-client-secret",
+        default=None,
+        help="GitHub OAuth App client secret for ArgoCD Dex connector",
+    )
+    parser.add_argument(
+        "--argocd-github-orgs",
+        default=None,
+        help="Comma-separated GitHub org slugs allowed to sign in via Dex",
+    )
 
     args = parser.parse_args()
 
@@ -333,8 +473,11 @@ def main():
         install_both = not args.argocd_only and not args.workflows_only
 
         if install_both or args.argocd_only:
+            cluster_payload = dict(config.model_dump()["cluster"])
+            cluster_payload.update(_build_argocd_sso_cli_overrides(args))
+            cluster_config = ClusterConfig.model_validate(cluster_payload)
             logger.info("Installing ArgoCD...")
-            install_argocd(config.cluster)
+            install_argocd(cluster_config)
 
         if install_both or args.workflows_only:
             logger.info("Installing Argo Workflows...")

--- a/tooling/launchpad/config.py
+++ b/tooling/launchpad/config.py
@@ -75,6 +75,22 @@ class ClusterConfig(LaunchpadBaseSettings):
         default="", description="Argo admin password (plaintext)"
     )
 
+    # Optional ArgoCD GitHub SSO configuration via Dex
+    argocd_github_sso_enabled: bool = Field(
+        default=False, description="Enable ArgoCD GitHub SSO via Dex"
+    )
+    argocd_github_oauth_client_id: str = Field(
+        default="", description="GitHub OAuth app client ID for ArgoCD Dex connector"
+    )
+    argocd_github_oauth_client_secret: str = Field(
+        default="",
+        description="GitHub OAuth app client secret for ArgoCD Dex connector",
+    )
+    argocd_github_orgs: str = Field(
+        default="",
+        description="Comma-separated GitHub org slugs allowed to sign in via Dex",
+    )
+
     @staticmethod
     def _load_cluster_domain_from_context() -> str:
         """

--- a/tooling/launchpad/kubernetes.py
+++ b/tooling/launchpad/kubernetes.py
@@ -172,18 +172,64 @@ class KubernetesClient:
         Raises:
             KubernetesError: If applying the resource fails
         """
-        try:
-            yaml_content = yaml.dump(doc, default_flow_style=False)
-            result = subprocess.run(
-                ["kubectl", "apply", "--server-side", "-f", "-", "-n", namespace],
-                input=yaml_content,
-                text=True,
-                capture_output=True,
-                check=True,
-            )
+        yaml_content = yaml.dump(doc, default_flow_style=False)
+        resource_name = doc.get("metadata", {}).get("name", "unknown")
+        resource_kind = doc.get("kind", "unknown")
 
-            resource_name = doc.get("metadata", {}).get("name", "unknown")
-            resource_kind = doc.get("kind", "unknown")
+        apply_command = [
+            "kubectl",
+            "apply",
+            "--server-side",
+            "-f",
+            "-",
+            "-n",
+            namespace,
+        ]
+
+        force_conflicts_used = False
+
+        try:
+            try:
+                result = subprocess.run(
+                    apply_command,
+                    input=yaml_content,
+                    text=True,
+                    capture_output=True,
+                    check=True,
+                )
+            except subprocess.CalledProcessError as e:
+                stderr = e.stderr or ""
+                has_apply_conflict = (
+                    "Apply failed with" in stderr and "conflict with" in stderr
+                )
+                if not has_apply_conflict:
+                    raise KubernetesError(
+                        f"Failed to apply {resource_kind} '{resource_name}': {stderr}"
+                    ) from e
+
+                self._logger.warning(
+                    (
+                        "Server-side apply conflict for %s '%s'; "
+                        "retrying once with --force-conflicts"
+                    ),
+                    resource_kind,
+                    resource_name,
+                )
+
+                force_conflicts_used = True
+                try:
+                    result = subprocess.run(
+                        apply_command + ["--force-conflicts"],
+                        input=yaml_content,
+                        text=True,
+                        capture_output=True,
+                        check=True,
+                    )
+                except subprocess.CalledProcessError as retry_error:
+                    raise KubernetesError(
+                        f"Failed to apply {resource_kind} '{resource_name}': "
+                        f"{retry_error.stderr}"
+                    ) from retry_error
 
             if "configured" in result.stdout:
                 self._logger.info(
@@ -204,12 +250,14 @@ class KubernetesClient:
                     resource_name,
                 )
 
-        except subprocess.CalledProcessError as e:
-            resource_name = doc.get("metadata", {}).get("name", "unknown")
-            resource_kind = doc.get("kind", "unknown")
-            raise KubernetesError(
-                f"Failed to apply {resource_kind} '{resource_name}': {e.stderr}"
-            ) from e
+            if force_conflicts_used:
+                self._logger.info(
+                    "%s '%s' applied with --force-conflicts",
+                    resource_kind,
+                    resource_name,
+                )
+        except KubernetesError:
+            raise
         except Exception as e:
             raise KubernetesError(f"Unexpected error applying resource: {e}") from e
 

--- a/tooling/tests/argo_install_test.py
+++ b/tooling/tests/argo_install_test.py
@@ -1,0 +1,173 @@
+"""
+Unit tests for Argo install helpers.
+"""
+
+import argparse
+from unittest import mock
+
+import pytest
+
+from launchpad.cli.argo_install import (
+    _build_argocd_sso_cli_overrides,
+    _build_dex_github_config,
+    _configure_argocd_github_sso,
+    _split_csv_values,
+)
+from launchpad.config import ClusterConfig
+from launchpad.exceptions import ConfigurationError
+
+
+class TestSplitCsvValues:
+    """
+    Test suite for _split_csv_values.
+    """
+
+    def test_split_csv_values_trims_and_removes_empty_values(self):
+        """
+        Test comma-separated values are normalized to a clean list.
+        """
+
+        result = _split_csv_values(" open-craft , , example-org,  ")
+
+        assert result == ["open-craft", "example-org"]
+
+
+class TestBuildDexGithubConfig:
+    """
+    Test suite for _build_dex_github_config.
+    """
+
+    def test_build_dex_github_config_contains_expected_connector(self):
+        """
+        Test generated Dex connector config includes key GitHub settings.
+        """
+
+        result = _build_dex_github_config("client-id", ["open-craft", "example-org"])
+
+        assert "type: github" in result
+        assert "clientID: client-id" in result
+        assert "clientSecret: $dex.github.clientSecret" in result
+        assert "      - name: open-craft" in result
+        assert "      - name: example-org" in result
+
+
+class TestBuildArgocdSsoCliOverrides:
+    """
+    Test suite for _build_argocd_sso_cli_overrides.
+    """
+
+    def test_build_argocd_sso_cli_overrides_returns_empty_dict(self):
+        """
+        Test no overrides are produced when CLI args are not provided.
+        """
+
+        args = argparse.Namespace(
+            argocd_github_sso_enabled=None,
+            argocd_github_oauth_client_id=None,
+            argocd_github_oauth_client_secret=None,
+            argocd_github_orgs=None,
+        )
+
+        assert _build_argocd_sso_cli_overrides(args) == {}
+
+    def test_build_argocd_sso_cli_overrides_returns_provided_values(self):
+        """
+        Test only explicitly provided CLI values are included as overrides.
+        """
+
+        args = argparse.Namespace(
+            argocd_github_sso_enabled=True,
+            argocd_github_oauth_client_id="client-id",
+            argocd_github_oauth_client_secret="client-secret",
+            argocd_github_orgs="open-craft,example-org",
+        )
+
+        assert _build_argocd_sso_cli_overrides(args) == {
+            "argocd_github_sso_enabled": True,
+            "argocd_github_oauth_client_id": "client-id",
+            "argocd_github_oauth_client_secret": "client-secret",
+            "argocd_github_orgs": "open-craft,example-org",
+        }
+
+
+class TestConfigureArgocdGithubSso:
+    """
+    Test suite for _configure_argocd_github_sso.
+    """
+
+    def test_configure_argocd_github_sso_skips_when_disabled(self):
+        """
+        Test SSO configuration is skipped when explicitly disabled.
+        """
+
+        k8s = mock.Mock()
+        cluster_config = ClusterConfig(cluster_domain="cluster.domain")
+
+        _configure_argocd_github_sso(k8s, cluster_config)
+
+        k8s.patch_config_map.assert_not_called()
+        k8s.patch_secret.assert_not_called()
+
+    def test_configure_argocd_github_sso_validates_required_settings(self):
+        """
+        Test SSO configuration fails when required values are missing.
+        """
+
+        k8s = mock.Mock()
+        cluster_config = ClusterConfig(
+            cluster_domain="cluster.domain",
+            argocd_github_sso_enabled=True,
+            argocd_github_oauth_client_id="",
+            argocd_github_oauth_client_secret="secret",
+            argocd_github_orgs="",
+        )
+
+        with pytest.raises(
+            ConfigurationError,
+            match=(
+                "LAUNCHPAD_ARGOCD_GITHUB_OAUTH_CLIENT_ID, "
+                "LAUNCHPAD_ARGOCD_GITHUB_ORGS"
+            ),
+        ):
+            _configure_argocd_github_sso(k8s, cluster_config)
+
+    def test_configure_argocd_github_sso_patches_configmap_and_secret(
+        self, monkeypatch
+    ):
+        """
+        Test SSO setup patches both argocd-cm and argocd-secret.
+        """
+
+        def _run_with_logging(_logger, _description, func, *args, **kwargs):
+            return func(*args, **kwargs)
+
+        monkeypatch.setattr(
+            "launchpad.cli.argo_install.run_command_with_logging",
+            _run_with_logging,
+        )
+
+        k8s = mock.Mock()
+        cluster_config = ClusterConfig(
+            cluster_domain="cluster.domain",
+            argocd_github_sso_enabled=True,
+            argocd_github_oauth_client_id="client-id",
+            argocd_github_oauth_client_secret="client-secret",
+            argocd_github_orgs="open-craft,example-org",
+        )
+
+        _configure_argocd_github_sso(k8s, cluster_config)
+
+        k8s.patch_config_map.assert_called_once()
+        patch_cm_kwargs = k8s.patch_config_map.call_args.kwargs
+        assert patch_cm_kwargs["name"] == "argocd-cm"
+        assert patch_cm_kwargs["namespace"] == "argocd"
+        assert patch_cm_kwargs["data"]["url"] == "https://argocd.cluster.domain"
+        assert patch_cm_kwargs["data"]["dex.config"] == _build_dex_github_config(
+            "client-id", ["open-craft", "example-org"]
+        )
+
+        k8s.patch_secret.assert_called_once_with(
+            name="argocd-secret",
+            namespace="argocd",
+            string_data={"dex.github.clientSecret": "client-secret"},
+        )

--- a/tooling/tests/config_test.py
+++ b/tooling/tests/config_test.py
@@ -36,6 +36,10 @@ class TestClusterConfig:
         assert config.argo_workflows_version == "stable"
         assert config.opencraft_manifests_version == "main"
         assert config.argo_admin_password == ""
+        assert config.argocd_github_sso_enabled is False
+        assert config.argocd_github_oauth_client_id == ""
+        assert config.argocd_github_oauth_client_secret == ""
+        assert config.argocd_github_orgs == ""
 
     def test_cluster_config_custom_values(self):
         """
@@ -48,6 +52,10 @@ class TestClusterConfig:
             argo_workflows_version="v3.4.0",
             opencraft_manifests_version="develop",
             argo_admin_password="custom_password",
+            argocd_github_sso_enabled=True,
+            argocd_github_oauth_client_id="client-id",
+            argocd_github_oauth_client_secret="client-secret",
+            argocd_github_orgs="open-craft,example-org",
         )
 
         assert config.cluster_domain == "test.cluster.domain"
@@ -55,6 +63,10 @@ class TestClusterConfig:
         assert config.argo_workflows_version == "v3.4.0"
         assert config.opencraft_manifests_version == "develop"
         assert config.argo_admin_password == "custom_password"
+        assert config.argocd_github_sso_enabled is True
+        assert config.argocd_github_oauth_client_id == "client-id"
+        assert config.argocd_github_oauth_client_secret == "client-secret"
+        assert config.argocd_github_orgs == "open-craft,example-org"
 
     def test_cluster_config_opencraft_manifests_url(self):
         """
@@ -118,12 +130,20 @@ class TestClusterConfig:
             {
                 "LAUNCHPAD_CLUSTER_DOMAIN": "env.cluster.domain",
                 "LAUNCHPAD_ARGOCD_VERSION": "v2.9.0",
+                "LAUNCHPAD_ARGOCD_GITHUB_SSO_ENABLED": "true",
+                "LAUNCHPAD_ARGOCD_GITHUB_OAUTH_CLIENT_ID": "env-client-id",
+                "LAUNCHPAD_ARGOCD_GITHUB_OAUTH_CLIENT_SECRET": "env-client-secret",
+                "LAUNCHPAD_ARGOCD_GITHUB_ORGS": "open-craft,example-org",
             },
         ):
             config = ClusterConfig()
 
             assert config.cluster_domain == "env.cluster.domain"
             assert config.argocd_version == "v2.9.0"
+            assert config.argocd_github_sso_enabled is True
+            assert config.argocd_github_oauth_client_id == "env-client-id"
+            assert config.argocd_github_oauth_client_secret == "env-client-secret"
+            assert config.argocd_github_orgs == "open-craft,example-org"
 
 
 class TestInstanceConfig:

--- a/tooling/tests/kubernetes_test.py
+++ b/tooling/tests/kubernetes_test.py
@@ -364,6 +364,60 @@ class TestKubernetesClient:
     @mock.patch("launchpad.kubernetes.client.ApiClient")
     @mock.patch("launchpad.kubernetes.config.load_kube_config")
     @mock.patch("launchpad.kubernetes.get_logger", return_value=mock.Mock())
+    @mock.patch("launchpad.kubernetes.subprocess.run")
+    @mock.patch("launchpad.kubernetes.yaml.safe_load_all")
+    def test_apply_manifest_conflict_retries_with_force_conflicts(
+        self,
+        mock_yaml_load,
+        mock_subprocess_run,
+        _mock_get_logger,
+        _mock_load_config,
+        mock_api_client_class,
+        _mock_apps_v1_class,
+        _mock_core_v1,
+        _mock_rbac_v1,
+    ):
+        """
+        Test server-side apply conflict retries once with --force-conflicts.
+        """
+
+        mock_api_client_instance = mock.Mock()
+        mock_api_client_class.return_value = mock_api_client_instance
+
+        manifest = "apiVersion: v1\nkind: Role\nmetadata:\n  name: argocd-server"
+        doc = {
+            "apiVersion": "v1",
+            "kind": "Role",
+            "metadata": {"name": "argocd-server"},
+        }
+        mock_yaml_load.return_value = [doc]
+
+        conflict_error = subprocess.CalledProcessError(
+            1,
+            ["kubectl", "apply"],
+            stderr='Apply failed with 1 conflict: conflict with "kubectl-patch"',
+        )
+        success_result = mock.Mock()
+        success_result.returncode = 0
+        success_result.stdout = "role/argocd-server configured"
+        success_result.stderr = ""
+        mock_subprocess_run.side_effect = [conflict_error, success_result]
+
+        k8s_client = KubernetesClient()
+        k8s_client.apply_manifest(manifest, namespace="argocd")
+
+        assert mock_subprocess_run.call_count == 2
+        first_command = mock_subprocess_run.call_args_list[0][0][0]
+        second_command = mock_subprocess_run.call_args_list[1][0][0]
+        assert "--force-conflicts" not in first_command
+        assert "--force-conflicts" in second_command
+
+    @mock.patch("launchpad.kubernetes.client.RbacAuthorizationV1Api")
+    @mock.patch("launchpad.kubernetes.client.CoreV1Api")
+    @mock.patch("launchpad.kubernetes.client.AppsV1Api")
+    @mock.patch("launchpad.kubernetes.client.ApiClient")
+    @mock.patch("launchpad.kubernetes.config.load_kube_config")
+    @mock.patch("launchpad.kubernetes.get_logger", return_value=mock.Mock())
     @mock.patch("launchpad.kubernetes.requests.get")
     @mock.patch("launchpad.kubernetes.subprocess.run")
     @mock.patch("launchpad.kubernetes.yaml.safe_load_all")


### PR DESCRIPTION
## Description

This PR adds ArgoCD GitHub SSO that can be optionally installed for a cluster.

## Testing instructions

1. try logging in to https://argocd.prod.opencraft.hosting/ with your GitHub user
2. You should see all 6 application tiles