### PR TITLE
fix: ensure Kubernetes config loaded properly

### DIFF
--- a/README.md
+++ b/README.md
@@ -327,9 +327,11 @@ export LAUNCHPAD_DOCKER_REGISTRY_CREDENTIALS="base64_encoded_credentials"
 The Launchpad CLI includes kubeconfig detection and setup:
 
 **Detection Order**:
-1. **Terraform/OpenTofu Output**: Checks for `tofu` or `terraform` commands and retrieves the `kubeconfig` output
-2. **Environment Variable**: Uses `KUBECONFIG_CONTENT` (supports both base64-encoded and plain text)
-3. **Existing Configuration**: Falls back to `~/.kube/config` if present
+1. **`KUBECONFIG`**: If set, and any path in the list (split with the platform path separator) is an existing file, that configuration is used and nothing is written
+2. **`KUBECONFIG_CONTENT`**: Inline kubeconfig (base64-encoded or plain text)
+3. **Terraform/OpenTofu Output**: Checks for `tofu` or `terraform` commands and reads the `kubeconfig_content` output from the `infrastructure/` directory
+
+When using `KUBECONFIG_CONTENT` or Terraform/OpenTofu output, the CLI writes kubeconfig to `infrastructure/.kubeconfig` when that directory exists, or to a private file under the system temp directory, then sets `KUBECONFIG` for the process. Your `~/.kube/config` is not modified.
 
 **Local Development**:
 ```bash
@@ -356,9 +358,10 @@ If no kubeconfig can be found, the CLI provides a helpful error message:
 
 ```
 No kubeconfig available. Please ensure one of the following:
-1. Run this command from a directory with infrastructure directory present
-2. Set KUBECONFIG_CONTENT environment variable
-3. Have a valid kubeconfig at ~/.kube/config
+1. Run this command from a directory with an infrastructure directory present
+   (so Terraform/OpenTofu can provide kubeconfig), or
+2. Set KUBECONFIG_CONTENT environment variable, or
+3. Set KUBECONFIG to an existing kubeconfig file path for your cluster
 ```
 
 ## Security & RBAC
@@ -582,9 +585,9 @@ For GitHub Actions workflows to function properly, configure the following secre
 
 The Launchpad CLI automatically detects and configures kubeconfig from multiple sources:
 
-1. **Terraform/OpenTofu Output** (Recommended): If you're in a directory with Terraform/OpenTofu that has a `kubeconfig` output, it will be used automatically
-2. **Environment Variable**: Set `KUBECONFIG_CONTENT` (base64-encoded or plain text)
-3. **Existing Config**: Falls back to `~/.kube/config` if present
+1. **`KUBECONFIG`**: If it points at existing kubeconfig file(s), those are used as-is
+2. **Terraform/OpenTofu Output** (Recommended): From `infrastructure/` with a `kubeconfig_content` output
+3. **`KUBECONFIG_CONTENT`**: Base64-encoded or plain text kubeconfig (written to a managed file and exposed via `KUBECONFIG` for that process; `~/.kube/config` is not overwritten)
 
 For GitHub Actions, configure:
 - `KUBECONFIG_CONTENT`: Base64-encoded kubeconfig file for cluster access

--- a/tooling/launchpad/kubeconfig.py
+++ b/tooling/launchpad/kubeconfig.py
@@ -12,19 +12,97 @@ import shutil
 import subprocess
 import tempfile
 from pathlib import Path
-from typing import Optional
+from typing import List, Optional
 
 from launchpad.exceptions import ConfigurationError
 from launchpad.utils import get_logger
 
-logger = None
+logger = get_logger(__name__)
 
 
-def _get_logger():
-    global logger  # pylint: disable=global-statement
-    if logger is None:
-        logger = get_logger(__name__)
-    return logger
+def _get_terraform_command() -> Optional[str]:
+    if shutil.which("tofu"):
+        logger.debug("Found tofu command")
+        return "tofu"
+
+    if shutil.which("terraform"):
+        logger.debug("Found terraform command")
+        return "terraform"
+
+    logger.debug("Neither tofu nor terraform commands found")
+    return None
+
+
+def _kubeconfig_paths_from_env() -> List[Path]:
+    raw = os.environ.get("KUBECONFIG", "")
+    if not raw.strip():
+        return []
+
+    return [
+        Path(entry.strip()).expanduser()
+        for entry in raw.split(os.pathsep)
+        if entry.strip()
+    ]
+
+
+def _has_usable_kubeconfig_env() -> bool:
+    for path in _kubeconfig_paths_from_env():
+        try:
+            if path.is_file():
+                logger.info("Using kubeconfig from KUBECONFIG entry %s", path)
+                return True
+        except OSError:
+            continue
+
+    return False
+
+
+def _atomic_write_file(path: Path, content: str) -> None:
+    parent = path.parent
+    parent.mkdir(parents=True, exist_ok=True)
+
+    tmp_path: Optional[Path] = None
+    try:
+        with tempfile.NamedTemporaryFile(
+            mode="w",
+            delete=False,
+            dir=parent,
+            prefix=".tmp-kubeconfig-",
+            encoding="utf-8",
+        ) as tmp_file:
+            tmp_file.write(content)
+            tmp_path = Path(tmp_file.name)
+
+        tmp_path.chmod(0o600)
+        tmp_path.replace(path)
+    except OSError:
+        if tmp_path and tmp_path.exists():
+            tmp_path.unlink(missing_ok=True)
+        raise
+
+
+def _resolve_infrastructure_dir(working_dir: Optional[Path] = None) -> Optional[Path]:
+    """
+    Resolve the infrastructure directory used for Terraform/OpenTofu and kubeconfig files.
+
+    Args:
+        working_dir: Repository or project root (directory that contains ``infrastructure/``).
+            Defaults to the current working directory.
+
+    Returns:
+        Path to ``infrastructure`` if it exists, otherwise None.
+    """
+    if not working_dir:
+        working_dir = Path.cwd()
+
+    if working_dir.name == "infrastructure":
+        working_dir = working_dir.parent
+
+    infrastructure_dir = working_dir / "infrastructure"
+    if not infrastructure_dir.is_dir():
+        return None
+
+    return infrastructure_dir
 
 
 def get_kubeconfig_from_terraform(working_dir: Optional[Path] = None) -> Optional[str]:
@@ -46,35 +124,21 @@ def get_kubeconfig_from_terraform(working_dir: Optional[Path] = None) -> Optiona
         ConfigurationError: If command execution fails
     """
 
-    command = None
-    if shutil.which("tofu"):
-        command = "tofu"
-        _get_logger().debug("Found tofu command")
-    elif shutil.which("terraform"):
-        command = "terraform"
-        _get_logger().debug("Found terraform command")
-    else:
-        _get_logger().debug("Neither tofu nor terraform commands found")
+    command = _get_terraform_command()
+    if not command:
         return None
 
-    if not working_dir:
-        working_dir = Path.cwd()
-
-    # If we're already in the infrastructure directory, go up one level
-    if working_dir.name == "infrastructure":
-        working_dir = working_dir.parent
-
-    # Check if infrastructure directory exists in the current working directory
-    infrastructure_dir = working_dir / "infrastructure"
-    if not infrastructure_dir.exists():
-        _get_logger().warning("Infrastructure directory not found in %s", working_dir)
+    infrastructure_dir = _resolve_infrastructure_dir(working_dir)
+    if not infrastructure_dir:
+        logger.warning(
+            "Infrastructure directory not found for working dir %s",
+            working_dir or Path.cwd(),
+        )
         return None
 
     try:
-        _get_logger().info("Getting kubeconfig from %s", infrastructure_dir)
-        _get_logger().info(
-            "Command: %s", [command, "output", "-raw", "kubeconfig_content"]
-        )
+        logger.info("Getting kubeconfig from %s", infrastructure_dir)
+        logger.info("Command: %s", [command, "output", "-raw", "kubeconfig_content"])
         result = subprocess.run(
             [command, "output", "-raw", "kubeconfig_content"],
             cwd=infrastructure_dir,
@@ -86,17 +150,15 @@ def get_kubeconfig_from_terraform(working_dir: Optional[Path] = None) -> Optiona
         raise ConfigurationError(f"Failed to execute {command} command: {exc}") from exc
 
     if result.returncode != 0:
-        _get_logger().debug(
-            "Failed to get kubeconfig from %s: %s", command, result.stderr
-        )
+        logger.debug("Failed to get kubeconfig from %s: %s", command, result.stderr)
         return None
 
     kubeconfig = result.stdout.strip()
     if not kubeconfig:
-        _get_logger().debug("Empty kubeconfig from %s output", command)
+        logger.debug("Empty kubeconfig from %s output", command)
         return None
 
-    _get_logger().debug("Raw output from %s: %s", command, repr(kubeconfig[:100]))
+    logger.debug("Raw output from %s: %s", command, repr(kubeconfig[:100]))
 
     # Check if the output looks like a valid kubeconfig
     if (
@@ -104,10 +166,10 @@ def get_kubeconfig_from_terraform(working_dir: Optional[Path] = None) -> Optiona
         or kubeconfig.startswith("\x1b[")
         or "Warning:" in kubeconfig
     ):
-        _get_logger().warning(
+        logger.warning(
             "Output from %s does not appear to be a valid kubeconfig", command
         )
-        _get_logger().warning(
+        logger.warning(
             "Validation failed - starts with apiVersion: %s, contains kind: Config: %s, starts with \\x1b[: %s, contains Warning: %s",
             kubeconfig.startswith("apiVersion:"),
             "kind: Config" in kubeconfig,
@@ -116,7 +178,7 @@ def get_kubeconfig_from_terraform(working_dir: Optional[Path] = None) -> Optiona
         )
         return None
 
-    _get_logger().info("Successfully retrieved kubeconfig from %s", command)
+    logger.info("Successfully retrieved kubeconfig from %s", command)
     return kubeconfig
 
 
@@ -133,74 +195,77 @@ def get_kubeconfig_from_env() -> Optional[str]:
     kubeconfig_content = os.environ.get("KUBECONFIG_CONTENT", "").strip()
 
     if not kubeconfig_content:
-        _get_logger().debug("KUBECONFIG_CONTENT environment variable not set")
+        logger.debug("KUBECONFIG_CONTENT environment variable not set")
         return None
 
     try:
         decoded = base64.b64decode(kubeconfig_content, validate=True).decode("utf-8")
-        _get_logger().info(
-            "Successfully decoded base64-encoded kubeconfig from environment"
-        )
+        logger.info("Successfully decoded base64-encoded kubeconfig from environment")
         return decoded
     except Exception:  # pylint: disable=broad-except
-        _get_logger().info("Using plain-text kubeconfig from environment")
+        logger.info("Using plain-text kubeconfig from environment")
         return kubeconfig_content
 
 
 def setup_kubeconfig(terraform_dir: Optional[Path] = None) -> None:
     """
-    Set up kubeconfig from available sources.
+    Set up kubeconfig from available sources for this process.
 
-    Attempts to retrieve kubeconfig in the following order:
-    1. Terraform/OpenTofu output (if not force_env)
-    2. KUBECONFIG_CONTENT environment variable
-    3. Use existing kubeconfig if available
+    Resolution order:
 
-    If kubeconfig is retrieved, it is written to ~/.kube/config.
+    1. If ``KUBECONFIG`` is set and any path in it (split with ``os.pathsep``) is an
+       existing regular file, use that and return without writing or mutating sources.
+    2. ``KUBECONFIG_CONTENT`` environment variable (plain or base64).
+    3. Terraform/OpenTofu ``kubeconfig_content`` output (from ``infrastructure/``).
+
+    When content comes from (2) or (3), it is written to either
+    ``infrastructure/.kubeconfig`` when an infrastructure directory
+    exists, or a private file under the system temporary directory. The process
+    environment variable ``KUBECONFIG`` is then set to that file's absolute path so
+    ``kubectl`` and client-go (``load_kube_config``) use it. This avoids overwriting
+    ``~/.kube/config``.
 
     Args:
-        terraform_dir: Directory containing Terraform/OpenTofu files.
-                      If None, uses current directory.
+        terraform_dir: Directory containing Terraform/OpenTofu files (repository root
+            or ``infrastructure`` parent). If None, uses the current working directory.
 
     Raises:
         ConfigurationError: If no valid kubeconfig can be obtained
     """
-    kubeconfig_content = None
+    if _has_usable_kubeconfig_env():
+        return
 
-    # Try Terraform/OpenTofu first
-    kubeconfig_content = get_kubeconfig_from_terraform(terraform_dir)
+    kubeconfig_content = get_kubeconfig_from_env()
 
-    # Fall back to environment variable
     if not kubeconfig_content:
-        kubeconfig_content = get_kubeconfig_from_env()
+        kubeconfig_content = get_kubeconfig_from_terraform(terraform_dir)
 
-    # Check if existing kubeconfig is available
-    kubeconfig_path = Path.home() / ".kube" / "config"
     if not kubeconfig_content:
-        if kubeconfig_path.exists():
-            _get_logger().info("Using existing kubeconfig at %s", kubeconfig_path)
-            return
-
         raise ConfigurationError(
             "No kubeconfig available. Please ensure one of the following:\n"
-            "1. Run this command from a directory with infrastructure directory present\n"
-            "2. Set KUBECONFIG_CONTENT environment variable\n"
-            "3. Have a valid kubeconfig at ~/.kube/config"
+            "1. Run this command from a directory with an infrastructure directory present\n"
+            "   (so Terraform/OpenTofu can provide kubeconfig), or\n"
+            "2. Set KUBECONFIG_CONTENT environment variable, or\n"
+            "3. Set KUBECONFIG to an existing kubeconfig file path for your cluster"
         )
 
-    try:
-        kubeconfig_path.parent.mkdir(parents=True, exist_ok=True)
-
+    infrastructure_dir = _resolve_infrastructure_dir(terraform_dir)
+    if infrastructure_dir:
+        kubeconfig_path = infrastructure_dir / ".kubeconfig"
+    else:
         with tempfile.NamedTemporaryFile(
-            mode="w", delete=False, dir=kubeconfig_path.parent
+            mode="w",
+            delete=False,
+            prefix="launchpad-kubeconfig-",
+            suffix=".yaml",
+            encoding="utf-8",
         ) as tmp_file:
-            tmp_file.write(kubeconfig_content)
-            tmp_path = Path(tmp_file.name)
+            kubeconfig_path = Path(tmp_file.name)
 
-        tmp_path.chmod(0o600)
-        tmp_path.replace(kubeconfig_path)
-
-        _get_logger().info("Kubeconfig written to %s", kubeconfig_path)
-
+    try:
+        _atomic_write_file(kubeconfig_path, kubeconfig_content)
     except (OSError, IOError) as exc:
         raise ConfigurationError(f"Failed to write kubeconfig: {exc}") from exc
+
+    os.environ["KUBECONFIG"] = str(kubeconfig_path.resolve())
+    logger.info("Kubeconfig written to %s", kubeconfig_path)

--- a/tooling/tests/kubeconfig_test.py
+++ b/tooling/tests/kubeconfig_test.py
@@ -21,6 +21,8 @@ from launchpad.kubeconfig import (
     setup_kubeconfig,
 )
 
+MINIMAL_KUBECONFIG = "apiVersion: v1\nkind: Config"
+
 
 class TestGetKubeconfigFromTerraform:
     """
@@ -46,14 +48,12 @@ class TestGetKubeconfigFromTerraform:
             "/usr/bin/tofu" if cmd == "tofu" else None
         )
         mock_run.return_value = Mock(
-            returncode=0,
-            stdout="apiVersion: v1\nkind: Config\n",
-            stderr="",
+            returncode=0, stdout=f"{MINIMAL_KUBECONFIG}\n", stderr=""
         )
 
         result = get_kubeconfig_from_terraform()
 
-        assert result == "apiVersion: v1\nkind: Config"
+        assert result == MINIMAL_KUBECONFIG
         mock_run.assert_called_once_with(
             ["tofu", "output", "-raw", "kubeconfig_content"],
             cwd=mock_infrastructure,
@@ -81,14 +81,12 @@ class TestGetKubeconfigFromTerraform:
             "/usr/bin/terraform" if cmd == "terraform" else None
         )
         mock_run.return_value = Mock(
-            returncode=0,
-            stdout="apiVersion: v1\nkind: Config\n",
-            stderr="",
+            returncode=0, stdout=f"{MINIMAL_KUBECONFIG}\n", stderr=""
         )
 
         result = get_kubeconfig_from_terraform()
 
-        assert result == "apiVersion: v1\nkind: Config"
+        assert result == MINIMAL_KUBECONFIG
         mock_run.assert_called_once_with(
             ["terraform", "output", "-raw", "kubeconfig_content"],
             cwd=mock_infrastructure,
@@ -112,7 +110,7 @@ class TestGetKubeconfigFromTerraform:
     @patch("launchpad.kubeconfig.shutil.which")
     @patch("launchpad.kubeconfig.subprocess.run")
     @patch("launchpad.kubeconfig.Path")
-    def test_with_working_directory(self, mock_path, mock_run, mock_check_command):
+    def test_with_working_directory(self, _mock_path, mock_run, mock_check_command):
         """
         Test with custom working directory.
         """
@@ -127,14 +125,12 @@ class TestGetKubeconfigFromTerraform:
             "/usr/bin/tofu" if cmd == "tofu" else None
         )
         mock_run.return_value = Mock(
-            returncode=0,
-            stdout="apiVersion: v1\nkind: Config\n",
-            stderr="",
+            returncode=0, stdout=f"{MINIMAL_KUBECONFIG}\n", stderr=""
         )
 
         result = get_kubeconfig_from_terraform(working_dir)
 
-        assert result == "apiVersion: v1\nkind: Config"
+        assert result == MINIMAL_KUBECONFIG
         mock_run.assert_called_once()
         assert mock_run.call_args[1]["cwd"] == mock_infrastructure
 
@@ -220,14 +216,12 @@ class TestGetKubeconfigFromTerraform:
             "/usr/bin/tofu" if cmd == "tofu" else None
         )
         mock_run.return_value = Mock(
-            returncode=0,
-            stdout="  \n  apiVersion: v1\nkind: Config  \n  ",
-            stderr="",
+            returncode=0, stdout=f"  \n  {MINIMAL_KUBECONFIG}  \n  ", stderr=""
         )
 
         result = get_kubeconfig_from_terraform()
 
-        assert result == "apiVersion: v1\nkind: Config"
+        assert result == MINIMAL_KUBECONFIG
 
 
 class TestGetKubeconfigFromEnv:
@@ -240,7 +234,7 @@ class TestGetKubeconfigFromEnv:
         Test retrieval of plain-text kubeconfig from environment.
         """
 
-        kubeconfig = "apiVersion: v1\nkind: Config"
+        kubeconfig = MINIMAL_KUBECONFIG
         monkeypatch.setenv("KUBECONFIG_CONTENT", kubeconfig)
 
         result = get_kubeconfig_from_env()
@@ -252,7 +246,7 @@ class TestGetKubeconfigFromEnv:
         Test retrieval of base64-encoded kubeconfig from environment.
         """
 
-        kubeconfig = "apiVersion: v1\nkind: Config"
+        kubeconfig = MINIMAL_KUBECONFIG
         encoded = base64.b64encode(kubeconfig.encode()).decode()
         monkeypatch.setenv("KUBECONFIG_CONTENT", encoded)
 
@@ -328,6 +322,11 @@ class TestSetupKubeconfig:
     Tests for setup_kubeconfig function.
     """
 
+    @pytest.fixture(autouse=True)
+    def _isolate_kubeconfig_env(self, monkeypatch):
+        monkeypatch.delenv("KUBECONFIG", raising=False)
+        monkeypatch.delenv("KUBECONFIG_CONTENT", raising=False)
+
     @patch("launchpad.kubeconfig.get_kubeconfig_from_terraform")
     def test_with_terraform_kubeconfig(self, mock_get_terraform):
         """
@@ -336,16 +335,19 @@ class TestSetupKubeconfig:
         mock_get_terraform.return_value = "kubeconfig from terraform"
 
         with tempfile.TemporaryDirectory() as tmpdir:
-            with patch("launchpad.kubeconfig.Path.home") as mock_home:
-                mock_home.return_value = Path(tmpdir)
-
+            root = Path(tmpdir)
+            (root / "infrastructure").mkdir(parents=True)
+            with patch("launchpad.kubeconfig.Path.cwd", return_value=root):
                 setup_kubeconfig()
 
-                kubeconfig_path = Path(tmpdir) / ".kube" / "config"
-                assert kubeconfig_path.exists()
-                assert kubeconfig_path.read_text() == "kubeconfig from terraform"
-
-                assert oct(kubeconfig_path.stat().st_mode)[-3:] == "600"
+            kubeconfig_path = root / "infrastructure" / ".kubeconfig"
+            assert kubeconfig_path.exists()
+            assert (
+                kubeconfig_path.read_text(encoding="utf-8")
+                == "kubeconfig from terraform"
+            )
+            assert oct(kubeconfig_path.stat().st_mode)[-3:] == "600"
+            assert os.environ["KUBECONFIG"] == str(kubeconfig_path.resolve())
 
         mock_get_terraform.assert_called_once_with(None)
 
@@ -353,48 +355,58 @@ class TestSetupKubeconfig:
     @patch("launchpad.kubeconfig.get_kubeconfig_from_env")
     def test_with_env_kubeconfig(self, mock_get_env, mock_get_terraform):
         """
-        Test setup using kubeconfig from environment when Terraform fails.
+        Test setup uses KUBECONFIG_CONTENT before Terraform output.
         """
-        mock_get_terraform.return_value = None
         mock_get_env.return_value = "kubeconfig from env"
+        mock_get_terraform.return_value = "kubeconfig from terraform"
 
         with tempfile.TemporaryDirectory() as tmpdir:
-            with patch("launchpad.kubeconfig.Path.home") as mock_home:
-                mock_home.return_value = Path(tmpdir)
-
+            root = Path(tmpdir)
+            with patch("launchpad.kubeconfig.Path.cwd", return_value=root):
                 setup_kubeconfig()
 
-                kubeconfig_path = Path(tmpdir) / ".kube" / "config"
-                assert kubeconfig_path.exists()
-                assert kubeconfig_path.read_text() == "kubeconfig from env"
+            written = Path(os.environ["KUBECONFIG"])
+            assert written.exists()
+            assert written.read_text(encoding="utf-8") == "kubeconfig from env"
+            assert oct(written.stat().st_mode)[-3:] == "600"
 
-                assert oct(kubeconfig_path.stat().st_mode)[-3:] == "600"
-
-        mock_get_terraform.assert_called_once()
+        mock_get_terraform.assert_not_called()
         mock_get_env.assert_called_once()
 
     @patch("launchpad.kubeconfig.get_kubeconfig_from_terraform")
     @patch("launchpad.kubeconfig.get_kubeconfig_from_env")
-    def test_with_existing_kubeconfig(self, mock_get_env, mock_get_terraform):
+    def test_short_circuits_when_kubeconfig_env_usable(
+        self, mock_get_env, mock_get_terraform, tmp_path, monkeypatch
+    ):
         """
-        Test when existing kubeconfig is available and no new one is provided.
+        When KUBECONFIG points at an existing file, do not fetch or write other sources.
         """
+        kube_file = tmp_path / "existing.yaml"
+        kube_file.write_text("apiVersion: v1\nkind: Config\n", encoding="utf-8")
+        monkeypatch.setenv("KUBECONFIG", str(kube_file))
 
         mock_get_terraform.return_value = None
         mock_get_env.return_value = None
 
-        with patch("launchpad.kubeconfig.Path") as mock_path_class:
-            mock_home = MagicMock()
-            mock_kubeconfig_path = MagicMock()
-            mock_kubeconfig_path.exists.return_value = True
+        setup_kubeconfig()
 
-            mock_path_class.home.return_value = mock_home
-            mock_home.__truediv__.return_value = mock_kubeconfig_path
+        mock_get_terraform.assert_not_called()
+        mock_get_env.assert_not_called()
 
-            setup_kubeconfig()
+    def test_kubeconfig_env_multiple_paths_second_usable(self, tmp_path, monkeypatch):
+        """
+        KUBECONFIG may list several paths (os.pathsep); the first existing file wins.
+        """
+        missing = tmp_path / "missing.yaml"
+        existing = tmp_path / "exists.yaml"
+        existing.write_text("apiVersion: v1\nkind: Config\n", encoding="utf-8")
+        monkeypatch.setenv("KUBECONFIG", f"{missing}{os.pathsep}{existing}")
 
-        mock_get_terraform.assert_called_once()
-        mock_get_env.assert_called_once()
+        with patch("launchpad.kubeconfig.get_kubeconfig_from_terraform") as mock_tf:
+            with patch("launchpad.kubeconfig.get_kubeconfig_from_env") as mock_env:
+                setup_kubeconfig()
+                mock_tf.assert_not_called()
+                mock_env.assert_not_called()
 
     @patch("launchpad.kubeconfig.get_kubeconfig_from_terraform")
     @patch("launchpad.kubeconfig.get_kubeconfig_from_env")
@@ -407,33 +419,32 @@ class TestSetupKubeconfig:
         mock_get_env.return_value = None
 
         with tempfile.TemporaryDirectory() as tmpdir:
-            with patch("launchpad.kubeconfig.Path.home") as mock_home:
-                mock_home.return_value = Path(tmpdir)
-
-                with pytest.raises(ConfigurationError, match="No kubeconfig available"):
+            root = Path(tmpdir)
+            with patch("launchpad.kubeconfig.Path.cwd", return_value=root):
+                with pytest.raises(
+                    ConfigurationError, match="Set KUBECONFIG to an existing"
+                ):
                     setup_kubeconfig()
 
     @patch("launchpad.kubeconfig.get_kubeconfig_from_terraform")
     @patch("launchpad.kubeconfig.get_kubeconfig_from_env")
-    def test_force_env_skips_terraform(self, mock_get_env, mock_get_terraform):
+    def test_prefers_env_over_terraform_output(self, mock_get_env, mock_get_terraform):
         """
-        Test that when terraform returns None, env is used as fallback.
+        Test that env kubeconfig is used even when Terraform would provide one.
         """
-        mock_get_terraform.return_value = None
         mock_get_env.return_value = "kubeconfig from env"
+        mock_get_terraform.return_value = "kubeconfig from terraform"
 
         with tempfile.TemporaryDirectory() as tmpdir:
-            with patch("launchpad.kubeconfig.Path.home") as mock_home:
-                mock_home.return_value = Path(tmpdir)
-
+            root = Path(tmpdir)
+            with patch("launchpad.kubeconfig.Path.cwd", return_value=root):
                 setup_kubeconfig()
 
-                kubeconfig_path = Path(tmpdir) / ".kube" / "config"
-                assert kubeconfig_path.exists()
-                assert kubeconfig_path.read_text() == "kubeconfig from env"
+            written = Path(os.environ["KUBECONFIG"])
+            assert written.exists()
+            assert written.read_text(encoding="utf-8") == "kubeconfig from env"
 
-        mock_get_terraform.assert_called_once()
-
+        mock_get_terraform.assert_not_called()
         mock_get_env.assert_called_once()
 
     @patch("launchpad.kubeconfig.get_kubeconfig_from_terraform")
@@ -444,15 +455,12 @@ class TestSetupKubeconfig:
         mock_get_terraform.return_value = "kubeconfig content"
         terraform_dir = Path("/custom/terraform/dir")
 
-        with tempfile.TemporaryDirectory() as tmpdir:
-            with patch("launchpad.kubeconfig.Path.home") as mock_home:
-                mock_home.return_value = Path(tmpdir)
+        with patch("launchpad.kubeconfig.Path.cwd", return_value=Path.cwd()):
+            setup_kubeconfig(terraform_dir=terraform_dir)
 
-                setup_kubeconfig(terraform_dir=terraform_dir)
-
-                kubeconfig_path = Path(tmpdir) / ".kube" / "config"
-                assert kubeconfig_path.exists()
-                assert kubeconfig_path.read_text() == "kubeconfig content"
+        written = Path(os.environ["KUBECONFIG"])
+        assert written.exists()
+        assert written.read_text(encoding="utf-8") == "kubeconfig content"
 
         mock_get_terraform.assert_called_once_with(terraform_dir)
 
@@ -464,40 +472,39 @@ class TestSetupKubeconfig:
         mock_get_terraform.return_value = "kubeconfig content"
 
         with tempfile.TemporaryDirectory() as tmpdir:
-            with patch("launchpad.kubeconfig.Path.home") as mock_home:
-                mock_home.return_value = Path(tmpdir)
-
-                kube_dir = Path(tmpdir) / ".kube"
-                kube_dir.mkdir()
-                kube_dir.chmod(0o444)
-
-                with pytest.raises(
-                    ConfigurationError, match="Failed to write kubeconfig"
-                ):
-                    setup_kubeconfig()
-
-                kube_dir.chmod(0o755)
+            root = Path(tmpdir)
+            infra = root / "infrastructure"
+            infra.mkdir(parents=True)
+            infra.chmod(0o444)
+            try:
+                with patch("launchpad.kubeconfig.Path.cwd", return_value=root):
+                    with pytest.raises(
+                        ConfigurationError, match="Failed to write kubeconfig"
+                    ):
+                        setup_kubeconfig()
+            finally:
+                infra.chmod(0o755)
 
     def test_integration_with_real_tempfile(self):
         """
         Integration test using real temporary directory.
         """
 
-        kubeconfig_content = "apiVersion: v1\nkind: Config"
+        kubeconfig_content = MINIMAL_KUBECONFIG
 
         with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            (root / "infrastructure").mkdir(parents=True)
             with patch(
                 "launchpad.kubeconfig.get_kubeconfig_from_terraform"
             ) as mock_terraform:
                 mock_terraform.return_value = kubeconfig_content
 
-                with patch("launchpad.kubeconfig.Path.home") as mock_home:
-                    mock_home.return_value = Path(tmpdir)
-
+                with patch("launchpad.kubeconfig.Path.cwd", return_value=root):
                     setup_kubeconfig()
 
-                    kubeconfig_path = Path(tmpdir) / ".kube" / "config"
-                    assert kubeconfig_path.exists()
-                    assert kubeconfig_path.read_text() == kubeconfig_content
+                kubeconfig_path = root / "infrastructure" / ".kubeconfig"
+                assert kubeconfig_path.exists()
+                assert kubeconfig_path.read_text(encoding="utf-8") == kubeconfig_content
 
-                    assert oct(kubeconfig_path.stat().st_mode)[-3:] == "600"
+                assert oct(kubeconfig_path.stat().st_mode)[-3:] == "600"


### PR DESCRIPTION
## Description

This PR fixes #23 by reordering the kubernetes config read order and does not fall back to the global Kubernetes config.

_Internal ticket: SE-6645_

## Test instructions

1. Set the ~/.kube/config content to something that's invalid
2. Generate the kubeconfig within the `infrastructure` directory
3. Run any commands that use `setup_kubeconfig` -> command should pass, globacl config intact
4. Base64 encode the generated kubeconfig, and set it as the `KUBECONFIG_CONTENT`
5. Run any commands that use `setup_kubeconfig` -> command should pass, globacl config intact
6. Move the file somewhere else, set `KUBECONFIG` to the new path
7.  Run any commands that use `setup_kubeconfig` -> command should pass, globacl config intact
8. Delete the file, unset the `KUBECONFIG` env var
9.  Run any commands that use `setup_kubeconfig` -> command should pass, globacl config intact