### PR TITLE
fix: render kubeconfig in correct location for workflow

### DIFF
--- a/.github/workflows/create-instance.yml
+++ b/.github/workflows/create-instance.yml
@@ -138,7 +138,7 @@ jobs:
         run: |
           echo "$TERRAFORM_SECRETS" > secrets.auto.tfvars
 
-      - name: Initialize Terraform
+      - name: Initialize Terraform and Render Kubeconfig
         working-directory: "infrastructure"
         env:
           TF_CLI_ARGS: "-no-color"
@@ -147,6 +147,8 @@ jobs:
         run: |
           tofu init -input=false
           tofu refresh
+          mkdir -p ~/.kube
+          tofu output -raw kubeconfig_content > ~/.kube/config
 
       - name: Create instance
         env:

--- a/.github/workflows/delete-instance.yml
+++ b/.github/workflows/delete-instance.yml
@@ -112,7 +112,7 @@ jobs:
         run: |
           echo "$TERRAFORM_SECRETS" > secrets.auto.tfvars
 
-      - name: Initialize Terraform
+      - name: Initialize Terraform and Render Kubeconfig
         working-directory: "infrastructure"
         env:
           TF_CLI_ARGS: "-no-color"
@@ -121,6 +121,8 @@ jobs:
         run: |
           tofu init -input=false
           tofu refresh
+          mkdir -p ~/.kube
+          tofu output -raw kubeconfig_content > ~/.kube/config
 
       - name: Delete instance
         env:


### PR DESCRIPTION
## Description

The PR fixes an issue where the workflow create/delete workflows would fail because the kubeconfig was being rendered in a location different from what the kubernetes python client was expecting.

Here we render the kubeconfig in the location expected by the kubernetes python client.

## Testing instructions

1. Change the [upstream workflow branch](https://github.com/open-craft/launchpad-cluster-template/blob/7acb47cdcfc3b8308249a13bb29e1cbc9f943a55/cluster-template/launchpad-%7B%7Bcookiecutter.cluster_slug_normalized%7D%7D-cluster/.github/workflows/create-instance.yml#L49) in your cluster's create/delete workflow files.
2. Trigger the create workflow
3. Ensure that workflow runs correctly

## Other information

[BB-10900](https://tasks.opencraft.com/browse/BB-10900)